### PR TITLE
fix: preserve styles when editing nodes and connectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+node_modules
+.dist
+build
+.DS_Store
+.env.local
+.env*
+.vscode
+.idea
+dist
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
-# schematicsApp
-This is an attempt to build out the framework for a figma-schematics app
+# Schematics Studio
+
+An experimental infinite-canvas diagram editor focused on building flowcharts, org charts, and lightweight schematic documents. The goal is to provide a Figma-like authoring experience optimised for nodes, connectors, and rapid iteration.
+
+## Getting Started
+
+```bash
+npm install
+npm run dev
+```
+
+If your environment blocks direct access to the public npm registry you may need to configure a mirror before installing:
+
+```bash
+npm config set registry https://registry.npmmirror.com
+```
+
+## Available Scripts
+
+- `npm run dev` – start the Vite development server.
+- `npm run build` – type-check and produce a production build.
+- `npm run preview` – preview the build output locally.
+
+## Current Capabilities
+
+- Infinite zoomable canvas with grid background and smooth panning.
+- Palette for primary flowchart node types (rectangle, rounded rectangle, ellipse, decision diamond) plus connector tool.
+- Straight connectors with selectable arrowheads, inline labels, and live preview when creating a connection.
+- Undo/redo with transaction batching while dragging.
+- Selection-based inspector for editing node size, fill, stroke, and connector styling.
+- Mini map that visualises the entire board and recentres the viewport on click.
+- Inline text editing for nodes and connectors with content-aware shortcuts (double-click to edit, escape to cancel).
+
+## Roadmap
+
+- Orthogonal routing improvements with preserved waypoints.
+- Frame and container support with auto-resize.
+- Export to PNG/SVG and import templates.
+- Realtime collaboration via CRDT and WebSocket layers.
+
+Contributions and feedback are welcome while the editor is still evolving.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Schematics Studio</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "schematicsapp",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "nanoid": "^4.0.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "zustand": "^4.5.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.2.1",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.11"
+  }
+}

--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,216 @@
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  padding: 16px;
+  gap: 16px;
+  position: relative;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.75);
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  box-shadow: 0 12px 40px rgba(2, 6, 23, 0.45);
+}
+
+.toolbar__group {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: 12px;
+  padding: 6px;
+}
+
+.toolbar__button {
+  min-width: 36px;
+  height: 36px;
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  color: #f1f5f9;
+  font-size: 15px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.12s ease, color 0.2s ease;
+}
+
+.toolbar__button:is(:hover, :focus-visible) {
+  background: rgba(59, 130, 246, 0.18);
+  outline: none;
+}
+
+.toolbar__button.is-active {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.35), rgba(14, 165, 233, 0.35));
+  color: #f8fafc;
+  box-shadow: 0 6px 20px rgba(59, 130, 246, 0.3);
+}
+
+.toolbar__button:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.toolbar__icon {
+  font-size: 16px;
+}
+
+.toolbar__status {
+  font-size: 14px;
+  font-weight: 500;
+  padding: 0 12px;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: 1fr 320px;
+  gap: 16px;
+  flex: 1;
+  min-height: 0;
+}
+
+.workspace__main {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.workspace__status {
+  position: absolute;
+  left: 16px;
+  bottom: 16px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 13px;
+  background: rgba(15, 23, 42, 0.72);
+  color: rgba(226, 232, 240, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  backdrop-filter: blur(10px);
+}
+
+.properties {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 18px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  color: #e2e8f0;
+  min-height: 0;
+}
+
+.properties__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.properties__clear {
+  border: none;
+  background: rgba(148, 163, 184, 0.15);
+  color: #f8fafc;
+  padding: 6px 12px;
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+.properties__section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+  border-radius: 14px;
+  background: rgba(30, 41, 59, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.properties__field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 14px;
+}
+
+.properties__field > span {
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.properties__field input,
+.properties__field select {
+  background: rgba(15, 23, 42, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 10px;
+  padding: 8px 10px;
+  color: #f8fafc;
+  font-size: 14px;
+}
+
+.properties__field input[type='color'] {
+  padding: 0;
+  height: 36px;
+}
+
+.properties__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.properties__danger {
+  margin-top: 8px;
+  padding: 8px 12px;
+  border-radius: 10px;
+  border: none;
+  background: rgba(248, 113, 113, 0.2);
+  color: #fecaca;
+  cursor: pointer;
+}
+
+.properties__empty {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.minimap {
+  position: absolute;
+  right: 24px;
+  bottom: 24px;
+  width: 240px;
+  height: 180px;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.65);
+  box-shadow: 0 16px 40px rgba(2, 6, 23, 0.4);
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.minimap__viewport {
+  fill: none;
+  stroke: rgba(96, 165, 250, 0.9);
+  stroke-width: 1.5;
+  stroke-dasharray: 6 6;
+}
+
+@media (max-width: 1200px) {
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .properties {
+    order: -1;
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,51 @@
+import React, { useMemo, useRef, useState } from 'react';
+import { Canvas, CanvasHandle } from './components/Canvas';
+import { Toolbar } from './components/Toolbar';
+import { MiniMap } from './components/MiniMap';
+import { PropertiesPanel } from './components/PropertiesPanel';
+import {
+  selectScene,
+  selectShowMiniMap,
+  selectTransform,
+  useSceneStore
+} from './state/sceneStore';
+import './App.css';
+
+export const App: React.FC = () => {
+  const canvasRef = useRef<CanvasHandle>(null);
+  const [viewport, setViewport] = useState<{ width: number; height: number }>({ width: 0, height: 0 });
+  const showMiniMap = useSceneStore(selectShowMiniMap);
+  const transform = useSceneStore(selectTransform);
+  const scene = useSceneStore(selectScene);
+
+  const nodeCount = scene.nodes.length;
+  const connectorCount = scene.connectors.length;
+
+  const statusText = useMemo(
+    () => `${nodeCount} nodes · ${connectorCount} connectors`,
+    [nodeCount, connectorCount]
+  );
+
+  return (
+    <div className="app-shell">
+      <Toolbar canvasRef={canvasRef} />
+      <div className="workspace">
+        <div className="workspace__main">
+          <Canvas ref={canvasRef} onViewportChange={setViewport} />
+          <div className="workspace__status">{statusText}</div>
+          {showMiniMap && (
+            <MiniMap
+              canvasRef={canvasRef}
+              viewport={viewport}
+              transform={transform}
+              scene={scene}
+            />
+          )}
+        </div>
+        <PropertiesPanel />
+      </div>
+    </div>
+  );
+};
+
+export default App;

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -1,0 +1,636 @@
+import React, {
+  ForwardedRef,
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
+import {
+  CanvasTransform,
+  NodeModel,
+  Tool,
+  Vec2
+} from '../types/scene';
+import {
+  GRID_SIZE,
+  boundsToSize,
+  centerOfBounds,
+  expandBounds,
+  getNodeById,
+  getSceneBounds,
+  getDefaultNodeSize,
+  screenToWorld
+} from '../utils/scene';
+import {
+  selectConnectors,
+  selectGridVisible,
+  selectNodes,
+  selectSelection,
+  selectTool,
+  useSceneStore
+} from '../state/sceneStore';
+import { DiagramNode } from './DiagramNode';
+import { DiagramConnector } from './DiagramConnector';
+import '../styles/canvas.css';
+
+const MIN_SCALE = 0.2;
+const MAX_SCALE = 4;
+const ZOOM_FACTOR = 1.1;
+const FIT_PADDING = 160;
+
+export interface CanvasHandle {
+  zoomIn: () => void;
+  zoomOut: () => void;
+  zoomToFit: () => void;
+  zoomToSelection: () => void;
+  zoomToHundred: () => void;
+  focusOn: (worldPoint: Vec2, scale?: number) => void;
+  getTransform: () => CanvasTransform;
+  setTransform: (transform: CanvasTransform) => void;
+}
+
+export interface CanvasProps {
+  onTransformChange?: (transform: CanvasTransform) => void;
+  onViewportChange?: (viewport: { width: number; height: number }) => void;
+}
+
+interface DragState {
+  pointerId: number;
+  nodeIds: string[];
+  lastWorld: Vec2;
+}
+
+interface PendingConnection {
+  sourceId: string;
+  worldPoint: Vec2;
+}
+
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+const CanvasComponent = (
+  { onTransformChange, onViewportChange }: CanvasProps,
+  ref: ForwardedRef<CanvasHandle>
+) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [transform, setTransformState] = useState<CanvasTransform>({ x: 0, y: 0, scale: 1 });
+  const [viewport, setViewport] = useState({ width: 0, height: 0 });
+  const [pendingConnection, setPendingConnection] = useState<PendingConnection | null>(null);
+  const [isPanning, setIsPanning] = useState(false);
+  const panStateRef = useRef<{ pointerId: number; last: { x: number; y: number } } | null>(null);
+  const dragStateRef = useRef<DragState | null>(null);
+  const connectionPointerRef = useRef<number | null>(null);
+  const initialFitDoneRef = useRef(false);
+
+  const nodes = useSceneStore(selectNodes);
+  const connectors = useSceneStore(selectConnectors);
+  const selection = useSceneStore(selectSelection);
+  const tool = useSceneStore(selectTool);
+  const gridVisible = useSceneStore(selectGridVisible);
+  const setSelection = useSceneStore((state) => state.setSelection);
+  const clearSelection = useSceneStore((state) => state.clearSelection);
+  const addNode = useSceneStore((state) => state.addNode);
+  const removeNode = useSceneStore((state) => state.removeNode);
+  const beginTransaction = useSceneStore((state) => state.beginTransaction);
+  const endTransaction = useSceneStore((state) => state.endTransaction);
+  const batchMove = useSceneStore((state) => state.batchMove);
+  const addConnector = useSceneStore((state) => state.addConnector);
+  const removeConnector = useSceneStore((state) => state.removeConnector);
+  const updateNode = useSceneStore((state) => state.updateNode);
+  const updateConnector = useSceneStore((state) => state.updateConnector);
+  const setGlobalTransform = useSceneStore((state) => state.setTransform);
+
+  const selectedNodeIds = selection.nodeIds;
+  const selectedConnectorIds = selection.connectorIds;
+
+  const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
+
+  const getRelativePoint = (event: PointerEvent | React.PointerEvent) => {
+    const rect = containerRef.current?.getBoundingClientRect();
+    if (!rect) {
+      return { x: 0, y: 0 };
+    }
+    return {
+      x: event.clientX - rect.left,
+      y: event.clientY - rect.top
+    };
+  };
+
+  const getWorldPoint = (event: PointerEvent | React.PointerEvent): Vec2 => {
+    const relative = getRelativePoint(event);
+    return screenToWorld(relative.x, relative.y, transform);
+  };
+
+  useEffect(() => {
+    setGlobalTransform(transform);
+    onTransformChange?.(transform);
+  }, [transform, onTransformChange, setGlobalTransform]);
+
+  useLayoutEffect(() => {
+    if (!containerRef.current) {
+      return;
+    }
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        setViewport({ width, height });
+        onViewportChange?.({ width, height });
+      }
+    });
+
+    observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, [onViewportChange]);
+
+  useEffect(() => {
+    if (initialFitDoneRef.current) {
+      return;
+    }
+    if (!viewport.width || !viewport.height) {
+      return;
+    }
+    if (!nodes.length) {
+      return;
+    }
+
+    const bounds = getSceneBounds({ nodes, connectors }, undefined);
+    if (!bounds) {
+      return;
+    }
+
+    const transformForFit = createTransformToFit(bounds, viewport);
+    if (transformForFit) {
+      setTransformState(transformForFit);
+      initialFitDoneRef.current = true;
+    }
+  }, [viewport, nodes, connectors]);
+
+  const handleWheel = (event: React.WheelEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    const direction = event.deltaY > 0 ? 1 : -1;
+    const factor = direction > 0 ? 1 / ZOOM_FACTOR : ZOOM_FACTOR;
+    const relative = getRelativePoint(event);
+    zoomAtPoint(relative, factor);
+  };
+
+  const zoomAtPoint = (point: { x: number; y: number }, factor: number) => {
+    setTransformState((previous) => {
+      const nextScale = clamp(previous.scale * factor, MIN_SCALE, MAX_SCALE);
+      const worldX = (point.x - previous.x) / previous.scale;
+      const worldY = (point.y - previous.y) / previous.scale;
+      const nextX = point.x - worldX * nextScale;
+      const nextY = point.y - worldY * nextScale;
+      return { x: nextX, y: nextY, scale: nextScale };
+    });
+  };
+
+  const zoomToFit = () => {
+    if (!viewport.width || !viewport.height) {
+      return;
+    }
+    const bounds = getSceneBounds({ nodes, connectors });
+    if (!bounds) {
+      return;
+    }
+    const expanded = expandBounds(bounds, FIT_PADDING);
+    const transformForFit = createTransformToFit(expanded, viewport);
+    if (transformForFit) {
+      setTransformState(transformForFit);
+    }
+  };
+
+  const zoomToSelection = () => {
+    if (!viewport.width || !viewport.height) {
+      return;
+    }
+    if (!selectedNodeIds.length) {
+      zoomToFit();
+      return;
+    }
+    const bounds = getSceneBounds({ nodes, connectors }, selectedNodeIds);
+    if (!bounds) {
+      return;
+    }
+    const expanded = expandBounds(bounds, FIT_PADDING / 2);
+    const transformForFit = createTransformToFit(expanded, viewport);
+    if (transformForFit) {
+      setTransformState(transformForFit);
+    }
+  };
+
+  const zoomToHundred = () => {
+    if (!viewport.width || !viewport.height) {
+      return;
+    }
+    const center = { x: viewport.width / 2, y: viewport.height / 2 };
+    setTransformState({ x: center.x, y: center.y, scale: 1 });
+  };
+
+  const focusOn = (worldPoint: Vec2, scale?: number) => {
+    if (!viewport.width || !viewport.height) {
+      return;
+    }
+    setTransformState((previous) => {
+      const nextScale = scale ? clamp(scale, MIN_SCALE, MAX_SCALE) : previous.scale;
+      return {
+        scale: nextScale,
+        x: viewport.width / 2 - worldPoint.x * nextScale,
+        y: viewport.height / 2 - worldPoint.y * nextScale
+      };
+    });
+  };
+
+  const setTransform = (next: CanvasTransform) => {
+    setTransformState({
+      x: next.x,
+      y: next.y,
+      scale: clamp(next.scale, MIN_SCALE, MAX_SCALE)
+    });
+  };
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      zoomIn: () => zoomAtPoint({ x: viewport.width / 2, y: viewport.height / 2 }, ZOOM_FACTOR),
+      zoomOut: () => zoomAtPoint({ x: viewport.width / 2, y: viewport.height / 2 }, 1 / ZOOM_FACTOR),
+      zoomToFit,
+      zoomToSelection,
+      zoomToHundred,
+      focusOn,
+      getTransform: () => transform,
+      setTransform
+    }),
+    [viewport, transform]
+  );
+
+  const beginPan = (event: React.PointerEvent<HTMLDivElement>) => {
+    panStateRef.current = {
+      pointerId: event.pointerId,
+      last: { x: event.clientX, y: event.clientY }
+    };
+    setIsPanning(true);
+    containerRef.current?.setPointerCapture(event.pointerId);
+  };
+
+  const handleBackgroundPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.target !== event.currentTarget) {
+      return;
+    }
+
+    if (tool === 'pan' || event.button === 1 || event.button === 2) {
+      beginPan(event);
+      return;
+    }
+
+    if (event.button !== 0) {
+      return;
+    }
+
+    if (tool === 'select') {
+      if (!event.shiftKey) {
+        clearSelection();
+      }
+      return;
+    }
+
+    if (tool === 'connector') {
+      return;
+    }
+
+    const worldPoint = getWorldPoint(event);
+    const { width, height } = getDefaultSizeForTool(tool);
+    const position = {
+      x: worldPoint.x - width / 2,
+      y: worldPoint.y - height / 2
+    };
+    addNode(tool as Extract<Tool, 'rectangle' | 'rounded-rectangle' | 'ellipse' | 'diamond'>, position);
+  };
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (panStateRef.current && panStateRef.current.pointerId === event.pointerId) {
+      const { last } = panStateRef.current;
+      const dx = event.clientX - last.x;
+      const dy = event.clientY - last.y;
+      if (dx !== 0 || dy !== 0) {
+        setTransformState((prev) => ({ x: prev.x + dx, y: prev.y + dy, scale: prev.scale }));
+      }
+      panStateRef.current = { pointerId: event.pointerId, last: { x: event.clientX, y: event.clientY } };
+      return;
+    }
+
+    const dragState = dragStateRef.current;
+    if (dragState && dragState.pointerId === event.pointerId) {
+      const worldPoint = getWorldPoint(event);
+      const delta = {
+        x: worldPoint.x - dragState.lastWorld.x,
+        y: worldPoint.y - dragState.lastWorld.y
+      };
+      if (Math.abs(delta.x) > 0.0001 || Math.abs(delta.y) > 0.0001) {
+        batchMove(dragState.nodeIds, delta);
+        dragStateRef.current = { ...dragState, lastWorld: worldPoint };
+      }
+      return;
+    }
+
+    if (connectionPointerRef.current === event.pointerId && pendingConnection) {
+      const worldPoint = getWorldPoint(event);
+      setPendingConnection({ ...pendingConnection, worldPoint });
+    }
+  };
+
+  const handlePointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (panStateRef.current?.pointerId === event.pointerId) {
+      panStateRef.current = null;
+      setIsPanning(false);
+      containerRef.current?.releasePointerCapture(event.pointerId);
+    }
+
+    if (dragStateRef.current?.pointerId === event.pointerId) {
+      dragStateRef.current = null;
+      endTransaction();
+      containerRef.current?.releasePointerCapture(event.pointerId);
+    }
+
+    if (connectionPointerRef.current === event.pointerId) {
+      setPendingConnection(null);
+      connectionPointerRef.current = null;
+      containerRef.current?.releasePointerCapture(event.pointerId);
+    }
+  };
+
+  const handleNodePointerDown = (event: React.PointerEvent, node: NodeModel) => {
+    if (tool === 'connector') {
+      const worldPoint = getWorldPoint(event);
+      setPendingConnection({ sourceId: node.id, worldPoint });
+      connectionPointerRef.current = event.pointerId;
+      containerRef.current?.setPointerCapture(event.pointerId);
+      return;
+    }
+
+    if (tool !== 'select') {
+      return;
+    }
+
+    const isSelected = selectedNodeIds.includes(node.id);
+    let nextSelection = selectedNodeIds;
+    if (event.shiftKey) {
+      nextSelection = isSelected
+        ? selectedNodeIds.filter((id) => id !== node.id)
+        : [...selectedNodeIds, node.id];
+    } else if (!isSelected) {
+      nextSelection = [node.id];
+    }
+    setSelection({ nodeIds: nextSelection, connectorIds: [] });
+
+    if (event.detail > 1) {
+      return;
+    }
+
+    const worldPoint = getWorldPoint(event);
+    const nodeIdsToDrag = nextSelection.length ? nextSelection : [node.id];
+    beginTransaction();
+    dragStateRef.current = {
+      pointerId: event.pointerId,
+      nodeIds: nodeIdsToDrag,
+      lastWorld: worldPoint
+    };
+    containerRef.current?.setPointerCapture(event.pointerId);
+  };
+
+  const handleNodePointerUp = (event: React.PointerEvent, node: NodeModel) => {
+    if (tool === 'connector' && pendingConnection && pendingConnection.sourceId !== node.id) {
+      addConnector(pendingConnection.sourceId, node.id);
+      setPendingConnection(null);
+      connectionPointerRef.current = null;
+      containerRef.current?.releasePointerCapture(event.pointerId);
+    }
+  };
+
+  const handleConnectorPointerDown = (event: React.PointerEvent, connectorId: string) => {
+    if (tool !== 'select') {
+      return;
+    }
+    if (event.button !== 0) {
+      return;
+    }
+    const alreadySelected = selectedConnectorIds.includes(connectorId);
+    let nextSelection = selectedConnectorIds;
+    if (event.shiftKey) {
+      nextSelection = alreadySelected
+        ? selectedConnectorIds.filter((id) => id !== connectorId)
+        : [...selectedConnectorIds, connectorId];
+    } else if (!alreadySelected) {
+      nextSelection = [connectorId];
+    }
+    setSelection({ nodeIds: [], connectorIds: nextSelection });
+  };
+
+  const handleDeleteSelection = useCallback(() => {
+    selectedNodeIds.forEach((id) => removeNode(id));
+    selectedConnectorIds.forEach((id) => removeConnector(id));
+  }, [selectedNodeIds, selectedConnectorIds, removeNode, removeConnector]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const active = document.activeElement as HTMLElement | null;
+      const isEditable =
+        active &&
+        (active.tagName === 'INPUT' ||
+          active.tagName === 'TEXTAREA' ||
+          active.isContentEditable);
+      if (isEditable) {
+        return;
+      }
+
+      if ((event.key === 'Delete' || event.key === 'Backspace')) {
+        event.preventDefault();
+        handleDeleteSelection();
+      }
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'a') {
+        event.preventDefault();
+        const allNodeIds = nodes.map((node) => node.id);
+        setSelection({ nodeIds: allNodeIds, connectorIds: [] });
+      }
+      if (event.key === 'Escape') {
+        clearSelection();
+        setPendingConnection(null);
+        if (connectionPointerRef.current !== null) {
+          containerRef.current?.releasePointerCapture(connectionPointerRef.current);
+          connectionPointerRef.current = null;
+        }
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [nodes, clearSelection, setSelection, handleDeleteSelection]);
+
+  const gridStyle = useMemo(() => {
+    const scaledSpacing = Math.max(GRID_SIZE * transform.scale, 8);
+    const offsetX = transform.x % scaledSpacing;
+    const offsetY = transform.y % scaledSpacing;
+    const opacity = gridVisible ? 0.7 : 0;
+    const color = 'rgba(148, 163, 184, 0.08)';
+    const dotColor = 'rgba(148, 163, 184, 0.18)';
+    return {
+      backgroundSize: `${scaledSpacing}px ${scaledSpacing}px, ${scaledSpacing}px ${scaledSpacing}px, ${scaledSpacing}px ${scaledSpacing}px`,
+      backgroundPosition: `${offsetX}px ${offsetY}px, ${offsetX}px ${offsetY}px, ${offsetX}px ${offsetY}px`,
+      backgroundImage: `linear-gradient(90deg, ${color} 1px, transparent 1px), linear-gradient(${color} 1px, transparent 1px), radial-gradient(${dotColor} 1px, transparent 1px)`,
+      transition: 'opacity 0.3s ease',
+      opacity
+    } as React.CSSProperties;
+  }, [transform, gridVisible]);
+
+  const pendingLine = useMemo(() => {
+    if (!pendingConnection) {
+      return null;
+    }
+    const sourceNode = getNodeById({ nodes, connectors }, pendingConnection.sourceId);
+    if (!sourceNode) {
+      return null;
+    }
+    const start = {
+      x: sourceNode.position.x + sourceNode.size.width / 2,
+      y: sourceNode.position.y + sourceNode.size.height / 2
+    };
+    return { start, end: pendingConnection.worldPoint };
+  }, [pendingConnection, nodes, connectors]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={`canvas-container ${isPanning ? 'is-panning' : ''}`}
+      onPointerDown={handleBackgroundPointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onWheel={handleWheel}
+    >
+      <div className="canvas-grid" style={gridStyle} />
+      <svg className="canvas-svg">
+        <defs>
+          <marker
+            id="arrow-end"
+            markerWidth="16"
+            markerHeight="16"
+            refX="12"
+            refY="6"
+            orient="auto"
+            markerUnits="strokeWidth"
+          >
+            <path d="M2 2 L12 6 L2 10 Z" fill="#e5e7eb" />
+          </marker>
+          <marker
+            id="arrow-start"
+            markerWidth="16"
+            markerHeight="16"
+            refX="4"
+            refY="6"
+            orient="auto"
+            markerUnits="strokeWidth"
+          >
+            <path d="M12 2 L2 6 L12 10 Z" fill="#e5e7eb" />
+          </marker>
+          <marker
+            id="dot-end"
+            markerWidth="10"
+            markerHeight="10"
+            refX="5"
+            refY="5"
+            markerUnits="strokeWidth"
+          >
+            <circle cx="5" cy="5" r="3" fill="#e5e7eb" />
+          </marker>
+          <marker
+            id="dot-start"
+            markerWidth="10"
+            markerHeight="10"
+            refX="5"
+            refY="5"
+            markerUnits="strokeWidth"
+          >
+            <circle cx="5" cy="5" r="3" fill="#e5e7eb" />
+          </marker>
+        </defs>
+        <g transform={`translate(${transform.x} ${transform.y}) scale(${transform.scale})`}>
+          {connectors.map((connector) => (
+            <DiagramConnector
+              key={connector.id}
+              connector={connector}
+              source={getNodeById({ nodes, connectors }, connector.sourceId)}
+              target={getNodeById({ nodes, connectors }, connector.targetId)}
+              selected={selectedConnectorIds.includes(connector.id)}
+              onPointerDown={(event) => handleConnectorPointerDown(event, connector.id)}
+              onUpdateLabel={(value) =>
+                updateConnector(connector.id, {
+                  label: value
+                })
+              }
+            />
+          ))}
+          {nodes.map((node) => (
+            <DiagramNode
+              key={node.id}
+              node={node}
+              selected={selectedNodeIds.includes(node.id)}
+              hovered={hoveredNodeId === node.id}
+              tool={tool as Tool}
+              onPointerDown={(event) => handleNodePointerDown(event, node)}
+              onPointerUp={(event) => handleNodePointerUp(event, node)}
+              onPointerEnter={() => setHoveredNodeId(node.id)}
+              onPointerLeave={() => setHoveredNodeId((prev) => (prev === node.id ? null : prev))}
+              onLabelChange={(value) => updateNode(node.id, { label: value })}
+            />
+          ))}
+        </g>
+        {pendingLine && (
+          <line
+            className="connector-pending"
+            x1={pendingLine.start.x * transform.scale + transform.x}
+            y1={pendingLine.start.y * transform.scale + transform.y}
+            x2={pendingLine.end.x * transform.scale + transform.x}
+            y2={pendingLine.end.y * transform.scale + transform.y}
+          />
+        )}
+      </svg>
+    </div>
+  );
+};
+
+const createTransformToFit = (
+  bounds: ReturnType<typeof getSceneBounds>,
+  viewport: { width: number; height: number }
+): CanvasTransform | null => {
+  if (!bounds) {
+    return null;
+  }
+  const size = boundsToSize(bounds);
+  const { width, height } = viewport;
+  if (!width || !height || !size.width || !size.height) {
+    return null;
+  }
+  const scale = clamp(Math.min(width / size.width, height / size.height), MIN_SCALE, MAX_SCALE);
+  const center = centerOfBounds(bounds);
+  return {
+    scale,
+    x: width / 2 - center.x * scale,
+    y: height / 2 - center.y * scale
+  };
+};
+
+const getDefaultSizeForTool = (tool: Tool) => {
+  switch (tool) {
+    case 'rectangle':
+    case 'rounded-rectangle':
+    case 'ellipse':
+    case 'diamond':
+      return getDefaultNodeSize(tool);
+    default:
+      return { width: GRID_SIZE * 4, height: GRID_SIZE * 4 };
+  }
+};
+
+export const Canvas = forwardRef(CanvasComponent);

--- a/src/components/DiagramConnector.tsx
+++ b/src/components/DiagramConnector.tsx
@@ -1,0 +1,149 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { ConnectorModel, NodeModel } from '../types/scene';
+
+interface DiagramConnectorProps {
+  connector: ConnectorModel;
+  source?: NodeModel;
+  target?: NodeModel;
+  selected: boolean;
+  onPointerDown: (event: React.PointerEvent<SVGPathElement>) => void;
+  onUpdateLabel: (value: string) => void;
+}
+
+const clampLabel = (value: string) => value.trim();
+
+const getNodeCenter = (node: NodeModel) => ({
+  x: node.position.x + node.size.width / 2,
+  y: node.position.y + node.size.height / 2
+});
+
+export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
+  connector,
+  source,
+  target,
+  selected,
+  onPointerDown,
+  onUpdateLabel
+}) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState(connector.label ?? '');
+
+  useEffect(() => {
+    if (!isEditing) {
+      setDraft(connector.label ?? '');
+    }
+  }, [connector.label, isEditing]);
+
+  if (!source || !target) {
+    return null;
+  }
+
+  const start = getNodeCenter(source);
+  const end = getNodeCenter(target);
+
+  const pathData = useMemo(() => {
+    if (connector.type === 'orthogonal' && connector.points?.length) {
+      const points = [start, ...connector.points, end];
+      return points.reduce((acc, point, index) => {
+        if (index === 0) {
+          return `M ${point.x} ${point.y}`;
+        }
+        return `${acc} L ${point.x} ${point.y}`;
+      }, '');
+    }
+    return `M ${start.x} ${start.y} L ${end.x} ${end.y}`;
+  }, [connector, start, end]);
+
+  const midpoint = useMemo(() => {
+    if (connector.type === 'orthogonal' && connector.points?.length) {
+      const points = [start, ...connector.points, end];
+      const midIndex = Math.floor(points.length / 2);
+      return points[midIndex];
+    }
+    return {
+      x: (start.x + end.x) / 2,
+      y: (start.y + end.y) / 2
+    };
+  }, [connector, start, end]);
+
+  const markerStart = connector.style.arrowStart === 'arrow'
+    ? 'url(#arrow-start)'
+    : connector.style.arrowStart === 'dot'
+    ? 'url(#dot-start)'
+    : undefined;
+  const markerEnd = connector.style.arrowEnd === 'arrow'
+    ? 'url(#arrow-end)'
+    : connector.style.arrowEnd === 'dot'
+    ? 'url(#dot-end)'
+    : undefined;
+
+  const handleLabelInput = (event: React.FormEvent<HTMLDivElement>) => {
+    setDraft(event.currentTarget.textContent ?? '');
+  };
+
+  const handleLabelBlur = () => {
+    setIsEditing(false);
+    const next = clampLabel(draft);
+    if (next !== (connector.label ?? '')) {
+      onUpdateLabel(next);
+    }
+  };
+
+  const handleLabelKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      (event.currentTarget as HTMLDivElement).blur();
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      setIsEditing(false);
+      setDraft(connector.label ?? '');
+    }
+  };
+
+  return (
+    <g className={`diagram-connector ${selected ? 'is-selected' : ''}`}>
+      <path
+        className="diagram-connector__hit"
+        d={pathData}
+        strokeWidth={24}
+        onPointerDown={onPointerDown}
+      />
+      <path
+        className="diagram-connector__line"
+        d={pathData}
+        stroke={connector.style.stroke}
+        strokeWidth={connector.style.strokeWidth}
+        strokeDasharray={connector.style.dashed ? '8 6' : undefined}
+        markerEnd={markerEnd}
+        markerStart={markerStart}
+        onPointerDown={onPointerDown}
+      />
+      {(connector.label || isEditing) && (
+        <foreignObject
+          x={midpoint.x - 80}
+          y={midpoint.y - 28}
+          width={160}
+          height={56}
+        >
+          <div
+            className={`diagram-connector__label ${isEditing ? 'is-editing' : ''}`}
+            contentEditable={isEditing}
+            suppressContentEditableWarning
+            spellCheck={false}
+            onInput={handleLabelInput}
+            onBlur={handleLabelBlur}
+            onKeyDown={handleLabelKeyDown}
+            onDoubleClick={(event) => {
+              event.stopPropagation();
+              setIsEditing(true);
+            }}
+          >
+            {draft || 'Label'}
+          </div>
+        </foreignObject>
+      )}
+    </g>
+  );
+};
+

--- a/src/components/DiagramNode.tsx
+++ b/src/components/DiagramNode.tsx
@@ -1,0 +1,162 @@
+import React, { useEffect, useState } from 'react';
+import { NodeModel, Tool } from '../types/scene';
+
+interface DiagramNodeProps {
+  node: NodeModel;
+  selected: boolean;
+  hovered: boolean;
+  tool: Tool;
+  onPointerDown: (event: React.PointerEvent<SVGGElement>) => void;
+  onPointerUp: (event: React.PointerEvent<SVGGElement>) => void;
+  onPointerEnter: () => void;
+  onPointerLeave: () => void;
+  onLabelChange: (value: string) => void;
+}
+
+const clampLabel = (value: string) => (value.trim().length ? value : 'Untitled');
+
+const renderShape = (
+  node: NodeModel,
+  {
+    fill,
+    stroke,
+    strokeWidth,
+    className
+  }: { fill: string; stroke: string; strokeWidth: number; className?: string }
+) => {
+  const { width, height } = node.size;
+  const cornerRadius = node.style.cornerRadius ?? 24;
+  const common = {
+    fill,
+    stroke,
+    strokeWidth,
+    className,
+    vectorEffect: 'non-scaling-stroke' as const
+  };
+
+  switch (node.type) {
+    case 'rectangle':
+      return <rect width={width} height={height} rx={8} {...common} />;
+    case 'rounded-rectangle':
+      return <rect width={width} height={height} rx={cornerRadius} {...common} />;
+    case 'ellipse':
+      return (
+        <ellipse cx={width / 2} cy={height / 2} rx={width / 2} ry={height / 2} {...common} />
+      );
+    case 'diamond':
+      return (
+        <polygon
+          points={`${width / 2},0 ${width},${height / 2} ${width / 2},${height} 0,${height / 2}`}
+          {...common}
+        />
+      );
+    default:
+      return <rect width={width} height={height} rx={8} {...common} />;
+  }
+};
+
+export const DiagramNode: React.FC<DiagramNodeProps> = ({
+  node,
+  selected,
+  hovered,
+  tool,
+  onPointerDown,
+  onPointerUp,
+  onPointerEnter,
+  onPointerLeave,
+  onLabelChange
+}) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState(node.label);
+
+  useEffect(() => {
+    if (!isEditing) {
+      setDraft(node.label);
+    }
+  }, [node.label, isEditing]);
+
+  const handleDoubleClick = (event: React.MouseEvent<SVGGElement>) => {
+    event.stopPropagation();
+    setIsEditing(true);
+  };
+
+  const handleLabelBlur = () => {
+    const nextValue = clampLabel(draft);
+    setIsEditing(false);
+    if (nextValue !== node.label) {
+      onLabelChange(nextValue);
+    }
+  };
+
+  const handleLabelInput = (event: React.FormEvent<HTMLDivElement>) => {
+    setDraft(event.currentTarget.textContent ?? '');
+  };
+
+  const handleLabelKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      (event.currentTarget as HTMLDivElement).blur();
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      setIsEditing(false);
+      setDraft(node.label);
+    }
+  };
+
+  const shapeElement = renderShape(node, {
+    fill: node.style.fill,
+    stroke: node.style.stroke,
+    strokeWidth: node.style.strokeWidth,
+    className: 'diagram-node__shape'
+  });
+
+  const outlineStroke = selected ? '#60a5fa' : hovered ? 'rgba(148, 163, 184, 0.4)' : 'transparent';
+  const outlineElement = renderShape(node, {
+    fill: 'transparent',
+    stroke: outlineStroke,
+    strokeWidth: outlineStroke === 'transparent' ? 0 : selected ? 3 : 2,
+    className: 'diagram-node__outline'
+  });
+
+  const cursor = tool === 'connector' ? 'crosshair' : 'move';
+
+  return (
+    <g
+      className={`diagram-node ${selected ? 'is-selected' : ''} ${hovered ? 'is-hovered' : ''}`}
+      transform={`translate(${node.position.x} ${node.position.y})`}
+      onPointerDown={onPointerDown}
+      onPointerUp={onPointerUp}
+      onPointerEnter={onPointerEnter}
+      onPointerLeave={onPointerLeave}
+      onDoubleClick={handleDoubleClick}
+      style={{ cursor }}
+    >
+      <g className="diagram-node__shadow" opacity={selected ? 0.45 : 0.25}>
+        <rect
+          x={-12}
+          y={-12}
+          width={node.size.width + 24}
+          height={node.size.height + 24}
+          rx={24}
+          fill="rgba(15, 23, 42, 0.35)"
+        />
+      </g>
+      {shapeElement}
+      {outlineElement}
+      <foreignObject x={12} y={12} width={Math.max(24, node.size.width - 24)} height={Math.max(24, node.size.height - 24)}>
+        <div
+          className={`diagram-node__label ${isEditing ? 'is-editing' : ''}`}
+          contentEditable={isEditing}
+          suppressContentEditableWarning
+          spellCheck={false}
+          onInput={handleLabelInput}
+          onBlur={handleLabelBlur}
+          onKeyDown={handleLabelKeyDown}
+        >
+          {draft}
+        </div>
+      </foreignObject>
+    </g>
+  );
+};

--- a/src/components/MiniMap.tsx
+++ b/src/components/MiniMap.tsx
@@ -1,0 +1,145 @@
+import React, { useMemo } from 'react';
+import { CanvasHandle } from './Canvas';
+import { SceneContent, Vec2, CanvasTransform } from '../types/scene';
+import { boundsToSize, expandBounds, getSceneBounds } from '../utils/scene';
+
+interface MiniMapProps {
+  scene: SceneContent;
+  transform: CanvasTransform;
+  viewport: { width: number; height: number };
+  canvasRef: React.RefObject<CanvasHandle>;
+}
+
+const MINI_WIDTH = 240;
+const MINI_HEIGHT = 180;
+const MINI_PADDING = 24;
+
+export const MiniMap: React.FC<MiniMapProps> = ({ scene, transform, viewport, canvasRef }) => {
+  const bounds = useMemo(() => {
+    const computed = getSceneBounds(scene);
+    if (!computed) {
+      return {
+        minX: -400,
+        minY: -320,
+        maxX: 400,
+        maxY: 320
+      };
+    }
+    return expandBounds(computed, 160);
+  }, [scene]);
+
+  const size = boundsToSize(bounds);
+  const scale = Math.min(
+    (MINI_WIDTH - MINI_PADDING * 2) / Math.max(size.width, 1),
+    (MINI_HEIGHT - MINI_PADDING * 2) / Math.max(size.height, 1)
+  );
+  const offset = {
+    x: (MINI_WIDTH - size.width * scale) / 2 - bounds.minX * scale,
+    y: (MINI_HEIGHT - size.height * scale) / 2 - bounds.minY * scale
+  };
+
+  const projectPoint = (point: Vec2) => ({
+    x: point.x * scale + offset.x,
+    y: point.y * scale + offset.y
+  });
+
+  const projectSize = (value: number) => value * scale;
+
+  const viewportRect = useMemo(() => {
+    if (!viewport.width || !viewport.height) {
+      return null;
+    }
+    const worldWidth = viewport.width / transform.scale;
+    const worldHeight = viewport.height / transform.scale;
+    const worldX = -transform.x / transform.scale;
+    const worldY = -transform.y / transform.scale;
+    const topLeft = projectPoint({ x: worldX, y: worldY });
+    return {
+      x: topLeft.x,
+      y: topLeft.y,
+      width: projectSize(worldWidth),
+      height: projectSize(worldHeight)
+    };
+  }, [viewport, transform]);
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    event.stopPropagation();
+    const rect = event.currentTarget.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+    const worldPoint = {
+      x: (x - offset.x) / scale,
+      y: (y - offset.y) / scale
+    };
+    canvasRef.current?.focusOn(worldPoint);
+  };
+
+  return (
+    <div className="minimap" onPointerDown={handlePointerDown}>
+      <svg width={MINI_WIDTH} height={MINI_HEIGHT}>
+        <rect
+          x={0.5}
+          y={0.5}
+          width={MINI_WIDTH - 1}
+          height={MINI_HEIGHT - 1}
+          rx={14}
+          ry={14}
+          fill="rgba(15, 23, 42, 0.85)"
+          stroke="rgba(148, 163, 184, 0.2)"
+        />
+        {scene.connectors.map((connector) => {
+          const source = scene.nodes.find((node) => node.id === connector.sourceId);
+          const target = scene.nodes.find((node) => node.id === connector.targetId);
+          if (!source || !target) {
+            return null;
+          }
+          const start = projectPoint({
+            x: source.position.x + source.size.width / 2,
+            y: source.position.y + source.size.height / 2
+          });
+          const end = projectPoint({
+            x: target.position.x + target.size.width / 2,
+            y: target.position.y + target.size.height / 2
+          });
+          return (
+            <line
+              key={connector.id}
+              x1={start.x}
+              y1={start.y}
+              x2={end.x}
+              y2={end.y}
+              stroke="rgba(148, 163, 184, 0.35)"
+              strokeWidth={1.5}
+              strokeLinecap="round"
+            />
+          );
+        })}
+        {scene.nodes.map((node) => {
+          const topLeft = projectPoint(node.position);
+          return (
+            <rect
+              key={node.id}
+              x={topLeft.x}
+              y={topLeft.y}
+              width={projectSize(node.size.width)}
+              height={projectSize(node.size.height)}
+              rx={node.type === 'ellipse' ? projectSize(node.size.width / 2) : 6}
+              ry={node.type === 'ellipse' ? projectSize(node.size.height / 2) : 6}
+              fill="rgba(59, 130, 246, 0.25)"
+              stroke="rgba(59, 130, 246, 0.6)"
+            />
+          );
+        })}
+        {viewportRect && (
+          <rect
+            className="minimap__viewport"
+            x={viewportRect.x}
+            y={viewportRect.y}
+            width={viewportRect.width}
+            height={viewportRect.height}
+          />
+        )}
+      </svg>
+    </div>
+  );
+};

--- a/src/components/PropertiesPanel.tsx
+++ b/src/components/PropertiesPanel.tsx
@@ -1,0 +1,183 @@
+import React, { useMemo } from 'react';
+import {
+  selectConnectors,
+  selectNodes,
+  selectSelection,
+  useSceneStore
+} from '../state/sceneStore';
+
+export const PropertiesPanel: React.FC = () => {
+  const selection = useSceneStore(selectSelection);
+  const nodes = useSceneStore(selectNodes);
+  const connectors = useSceneStore(selectConnectors);
+  const updateNode = useSceneStore((state) => state.updateNode);
+  const updateConnector = useSceneStore((state) => state.updateConnector);
+  const removeNode = useSceneStore((state) => state.removeNode);
+  const removeConnector = useSceneStore((state) => state.removeConnector);
+  const clearSelection = useSceneStore((state) => state.clearSelection);
+
+  const selectedNode = useMemo(() => {
+    if (!selection.nodeIds.length) {
+      return null;
+    }
+    const [first] = selection.nodeIds;
+    return nodes.find((node) => node.id === first) ?? null;
+  }, [selection.nodeIds, nodes]);
+
+  const selectedConnector = useMemo(() => {
+    if (!selection.connectorIds.length) {
+      return null;
+    }
+    const [first] = selection.connectorIds;
+    return connectors.find((connector) => connector.id === first) ?? null;
+  }, [selection.connectorIds, connectors]);
+
+  if (!selectedNode && !selectedConnector) {
+    return (
+      <aside className="properties">
+        <div className="properties__empty">
+          <h3>Properties</h3>
+          <p>Select a node or connector to edit its properties.</p>
+        </div>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className="properties">
+      <div className="properties__header">
+        <h3>Properties</h3>
+        <button type="button" onClick={clearSelection} className="properties__clear">
+          Clear
+        </button>
+      </div>
+      {selectedNode && (
+        <section className="properties__section">
+          <h4>{selectedNode.type.replace('-', ' ')}</h4>
+          <label className="properties__field">
+            <span>Label</span>
+            <input
+              type="text"
+              value={selectedNode.label}
+              onChange={(event) => updateNode(selectedNode.id, { label: event.target.value })}
+            />
+          </label>
+          <div className="properties__grid">
+            <label className="properties__field">
+              <span>Width</span>
+              <input
+                type="number"
+                value={Math.round(selectedNode.size.width)}
+                onChange={(event) =>
+                  updateNode(selectedNode.id, {
+                    size: {
+                      width: Math.max(40, Number(event.target.value)),
+                      height: selectedNode.size.height
+                    }
+                  })
+                }
+              />
+            </label>
+            <label className="properties__field">
+              <span>Height</span>
+              <input
+                type="number"
+                value={Math.round(selectedNode.size.height)}
+                onChange={(event) =>
+                  updateNode(selectedNode.id, {
+                    size: {
+                      width: selectedNode.size.width,
+                      height: Math.max(40, Number(event.target.value))
+                    }
+                  })
+                }
+              />
+            </label>
+          </div>
+          <div className="properties__grid">
+            <label className="properties__field">
+              <span>Fill</span>
+              <input
+                type="color"
+                value={selectedNode.style.fill}
+                onChange={(event) => updateNode(selectedNode.id, { style: { fill: event.target.value } })}
+              />
+            </label>
+            <label className="properties__field">
+              <span>Stroke</span>
+              <input
+                type="color"
+                value={selectedNode.style.stroke}
+                onChange={(event) => updateNode(selectedNode.id, { style: { stroke: event.target.value } })}
+              />
+            </label>
+          </div>
+          <label className="properties__field">
+            <span>Stroke Width</span>
+            <input
+              type="number"
+              min={1}
+              max={12}
+              value={selectedNode.style.strokeWidth}
+              onChange={(event) =>
+                updateNode(selectedNode.id, { style: { strokeWidth: Number(event.target.value) } })
+              }
+            />
+          </label>
+          <button
+            type="button"
+            className="properties__danger"
+            onClick={() => removeNode(selectedNode.id)}
+          >
+            Delete Node
+          </button>
+        </section>
+      )}
+      {selectedConnector && (
+        <section className="properties__section">
+          <h4>Connector</h4>
+          <label className="properties__field">
+            <span>Label</span>
+            <input
+              type="text"
+              value={selectedConnector.label ?? ''}
+              onChange={(event) => updateConnector(selectedConnector.id, { label: event.target.value })}
+            />
+          </label>
+          <label className="properties__field">
+            <span>Stroke</span>
+            <input
+              type="color"
+              value={selectedConnector.style.stroke}
+              onChange={(event) =>
+                updateConnector(selectedConnector.id, { style: { stroke: event.target.value } })
+              }
+            />
+          </label>
+          <label className="properties__field">
+            <span>Thickness</span>
+            <input
+              type="number"
+              min={1}
+              max={12}
+              value={selectedConnector.style.strokeWidth}
+              onChange={(event) =>
+                updateConnector(selectedConnector.id, {
+                  style: { strokeWidth: Number(event.target.value) }
+                })
+              }
+            />
+          </label>
+          <button
+            type="button"
+            className="properties__danger"
+            onClick={() => removeConnector(selectedConnector.id)}
+          >
+            Delete Connector
+          </button>
+        </section>
+      )}
+    </aside>
+  );
+};
+

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { CanvasHandle } from './Canvas';
+import {
+  selectCanRedo,
+  selectCanUndo,
+  selectGridVisible,
+  selectShowMiniMap,
+  selectTool,
+  selectTransform,
+  useSceneStore
+} from '../state/sceneStore';
+import { Tool } from '../types/scene';
+
+interface ToolbarProps {
+  canvasRef: React.RefObject<CanvasHandle>;
+}
+
+const toolButtons: Array<{ id: Tool; label: string; icon: string; shortcut?: string }> = [
+  { id: 'select', label: 'Select', icon: '🖱️', shortcut: 'V' },
+  { id: 'pan', label: 'Pan', icon: '✋', shortcut: 'Space' },
+  { id: 'rectangle', label: 'Rectangle', icon: '▭', shortcut: 'R' },
+  { id: 'rounded-rectangle', label: 'Terminator', icon: '⬒', shortcut: 'T' },
+  { id: 'ellipse', label: 'Ellipse', icon: '⬭', shortcut: 'O' },
+  { id: 'diamond', label: 'Decision', icon: '◇', shortcut: 'D' },
+  { id: 'connector', label: 'Connector', icon: '↦', shortcut: 'L' }
+];
+
+export const Toolbar: React.FC<ToolbarProps> = ({ canvasRef }) => {
+  const tool = useSceneStore(selectTool);
+  const setTool = useSceneStore((state) => state.setTool);
+  const undo = useSceneStore((state) => state.undo);
+  const redo = useSceneStore((state) => state.redo);
+  const canUndo = useSceneStore(selectCanUndo);
+  const canRedo = useSceneStore(selectCanRedo);
+  const gridVisible = useSceneStore(selectGridVisible);
+  const toggleGrid = useSceneStore((state) => state.toggleGrid);
+  const snapToGrid = useSceneStore((state) => state.snapToGrid);
+  const toggleSnap = useSceneStore((state) => state.toggleSnap);
+  const showMiniMap = useSceneStore(selectShowMiniMap);
+  const setShowMiniMap = useSceneStore((state) => state.setShowMiniMap);
+  const transform = useSceneStore(selectTransform);
+
+  const handleZoom = (type: 'in' | 'out' | 'fit' | 'selection' | 'hundred') => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return;
+    }
+    switch (type) {
+      case 'in':
+        canvas.zoomIn();
+        break;
+      case 'out':
+        canvas.zoomOut();
+        break;
+      case 'fit':
+        canvas.zoomToFit();
+        break;
+      case 'selection':
+        canvas.zoomToSelection();
+        break;
+      case 'hundred':
+        canvas.zoomToHundred();
+        break;
+    }
+  };
+
+  return (
+    <div className="toolbar">
+      <div className="toolbar__group">
+        {toolButtons.map((button) => (
+          <button
+            key={button.id}
+            type="button"
+            className={`toolbar__button ${tool === button.id ? 'is-active' : ''}`}
+            aria-pressed={tool === button.id}
+            onClick={() => setTool(button.id)}
+            title={`${button.label}${button.shortcut ? ` (${button.shortcut})` : ''}`}
+          >
+            <span className="toolbar__icon" aria-hidden>
+              {button.icon}
+            </span>
+          </button>
+        ))}
+      </div>
+      <div className="toolbar__group">
+        <button type="button" className="toolbar__button" onClick={() => undo()} disabled={!canUndo} title="Undo (⌘Z)">
+          ⎌
+        </button>
+        <button type="button" className="toolbar__button" onClick={() => redo()} disabled={!canRedo} title="Redo (⇧⌘Z)">
+          ↻
+        </button>
+      </div>
+      <div className="toolbar__group">
+        <button type="button" className="toolbar__button" onClick={() => handleZoom('fit')} title="Zoom to Fit">
+          Fit
+        </button>
+        <button type="button" className="toolbar__button" onClick={() => handleZoom('selection')} title="Zoom to Selection">
+          Sel
+        </button>
+        <button type="button" className="toolbar__button" onClick={() => handleZoom('hundred')} title="100%">
+          100%
+        </button>
+        <button type="button" className="toolbar__button" onClick={() => handleZoom('out')} title="Zoom Out">
+          −
+        </button>
+        <button type="button" className="toolbar__button" onClick={() => handleZoom('in')} title="Zoom In">
+          +
+        </button>
+        <div className="toolbar__status">{Math.round(transform.scale * 100)}%</div>
+      </div>
+      <div className="toolbar__group">
+        <button
+          type="button"
+          className={`toolbar__button ${gridVisible ? 'is-active' : ''}`}
+          onClick={toggleGrid}
+          title="Toggle Grid"
+        >
+          Grid
+        </button>
+        <button
+          type="button"
+          className={`toolbar__button ${snapToGrid ? 'is-active' : ''}`}
+          onClick={toggleSnap}
+          title="Snap to Grid"
+        >
+          Snap
+        </button>
+        <button
+          type="button"
+          className={`toolbar__button ${showMiniMap ? 'is-active' : ''}`}
+          onClick={() => setShowMiniMap(!showMiniMap)}
+          title="Toggle Mini Map"
+        >
+          Map
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles/global.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/state/sceneStore.ts
+++ b/src/state/sceneStore.ts
@@ -1,0 +1,394 @@
+import { nanoid } from 'nanoid';
+import { create } from 'zustand';
+import {
+  CanvasTransform,
+  ConnectorModel,
+  NodeKind,
+  NodeModel,
+  SceneContent,
+  SelectionState,
+  Tool,
+  Vec2
+} from '../types/scene';
+import {
+  GRID_SIZE,
+  cloneScene,
+  createNodeModel,
+  getNodeById,
+  getSceneBounds
+} from '../utils/scene';
+
+const HISTORY_LIMIT = 64;
+
+interface SceneHistory {
+  past: SceneContent[];
+  future: SceneContent[];
+}
+
+interface SceneStoreState {
+  scene: SceneContent;
+  history: SceneHistory;
+  selection: SelectionState;
+  tool: Tool;
+  gridVisible: boolean;
+  snapToGrid: boolean;
+  showMiniMap: boolean;
+  isTransaction: boolean;
+  transform: CanvasTransform;
+}
+
+interface SceneStoreActions {
+  setTool: (tool: Tool) => void;
+  addNode: (type: NodeKind, position: Vec2) => NodeModel;
+  updateNode: (id: string, patch: Partial<NodeModel>) => void;
+  moveNode: (id: string, position: Vec2) => void;
+  batchMove: (ids: string[], delta: Vec2) => void;
+  removeNode: (id: string) => void;
+  addConnector: (sourceId: string, targetId: string) => ConnectorModel | null;
+  updateConnector: (id: string, patch: Partial<ConnectorModel>) => void;
+  removeConnector: (id: string) => void;
+  setSelection: (selection: SelectionState) => void;
+  clearSelection: () => void;
+  toggleGrid: () => void;
+  toggleSnap: () => void;
+  setShowMiniMap: (value: boolean) => void;
+  undo: () => void;
+  redo: () => void;
+  beginTransaction: () => void;
+  endTransaction: () => void;
+  setTransform: (transform: CanvasTransform) => void;
+}
+
+export type SceneStore = SceneStoreState & SceneStoreActions;
+
+const defaultConnectorStyle: ConnectorModel['style'] = {
+  stroke: '#e5e7eb',
+  strokeWidth: 2,
+  arrowEnd: 'arrow',
+  arrowStart: 'none'
+};
+
+const createInitialScene = (): SceneContent => {
+  const start = createNodeModel('ellipse', { x: -380, y: -140 }, 'Start');
+  const collect = createNodeModel('rectangle', { x: -40, y: -180 }, 'Collect Input');
+  const decision = createNodeModel('diamond', { x: 320, y: -200 }, 'Valid?');
+  const done = createNodeModel('rounded-rectangle', { x: 700, y: -160 }, 'Archive');
+
+  const connectors: ConnectorModel[] = [
+    {
+      id: nanoid(),
+      type: 'straight',
+      sourceId: start.id,
+      targetId: collect.id,
+      style: { ...defaultConnectorStyle },
+      label: 'Begin'
+    },
+    {
+      id: nanoid(),
+      type: 'straight',
+      sourceId: collect.id,
+      targetId: decision.id,
+      style: { ...defaultConnectorStyle }
+    },
+    {
+      id: nanoid(),
+      type: 'straight',
+      sourceId: decision.id,
+      targetId: done.id,
+      style: { ...defaultConnectorStyle },
+      label: 'Yes'
+    }
+  ];
+
+  return {
+    nodes: [start, collect, decision, done],
+    connectors
+  };
+};
+
+const initialState: SceneStoreState = {
+  scene: createInitialScene(),
+  history: { past: [], future: [] },
+  selection: { nodeIds: [], connectorIds: [] },
+  tool: 'select',
+  gridVisible: true,
+  snapToGrid: true,
+  showMiniMap: true,
+  isTransaction: false,
+  transform: { x: 0, y: 0, scale: 1 }
+};
+
+const withSceneChange = (state: SceneStoreState, nextScene: SceneContent) => {
+  if (state.isTransaction) {
+    return { scene: nextScene };
+  }
+
+  const updatedPast = [...state.history.past, cloneScene(state.scene)];
+  if (updatedPast.length > HISTORY_LIMIT) {
+    updatedPast.shift();
+  }
+
+  return {
+    scene: nextScene,
+    history: {
+      past: updatedPast,
+      future: []
+    }
+  };
+};
+
+export const useSceneStore = create<SceneStore>((set, get) => ({
+  ...initialState,
+  setTool: (tool) => set({ tool }),
+  addNode: (type, position) => {
+    const state = get();
+    const snappedPosition = state.snapToGrid
+      ? {
+          x: Math.round(position.x / GRID_SIZE) * GRID_SIZE,
+          y: Math.round(position.y / GRID_SIZE) * GRID_SIZE
+        }
+      : position;
+
+    const node = createNodeModel(type, snappedPosition);
+
+    set((current) => {
+      const scene = cloneScene(current.scene);
+      scene.nodes.push(node);
+      return {
+        ...withSceneChange(current, scene),
+        selection: { nodeIds: [node.id], connectorIds: [] },
+        tool: 'select'
+      };
+    });
+
+    return node;
+  },
+  updateNode: (id, patch) =>
+    set((current) => {
+      const scene = cloneScene(current.scene);
+      const node = scene.nodes.find((item) => item.id === id);
+      if (!node) {
+        return {};
+      }
+
+      const { position, size, style, ...rest } = patch;
+
+      if (position) {
+        node.position = { ...node.position, ...position };
+      }
+      if (size) {
+        node.size = { ...node.size, ...size };
+      }
+      if (style) {
+        node.style = { ...node.style, ...style };
+      }
+
+      Object.assign(node, rest);
+
+      return withSceneChange(current, scene);
+    }),
+  moveNode: (id, position) =>
+    set((current) => {
+      const scene = cloneScene(current.scene);
+      const node = scene.nodes.find((item) => item.id === id);
+      if (!node) {
+        return {};
+      }
+
+      node.position = { ...position };
+      if (current.snapToGrid) {
+        node.position.x = Math.round(node.position.x / GRID_SIZE) * GRID_SIZE;
+        node.position.y = Math.round(node.position.y / GRID_SIZE) * GRID_SIZE;
+      }
+
+      if (current.isTransaction) {
+        return { scene };
+      }
+
+      return withSceneChange(current, scene);
+    }),
+  batchMove: (ids, delta) =>
+    set((current) => {
+      const scene = cloneScene(current.scene);
+      let changed = false;
+      scene.nodes.forEach((node) => {
+        if (ids.includes(node.id)) {
+          node.position = {
+            x: node.position.x + delta.x,
+            y: node.position.y + delta.y
+          };
+          if (current.snapToGrid) {
+            node.position.x = Math.round(node.position.x / GRID_SIZE) * GRID_SIZE;
+            node.position.y = Math.round(node.position.y / GRID_SIZE) * GRID_SIZE;
+          }
+          changed = true;
+        }
+      });
+
+      if (!changed) {
+        return {};
+      }
+
+      if (current.isTransaction) {
+        return { scene };
+      }
+
+      return withSceneChange(current, scene);
+    }),
+  removeNode: (id) =>
+    set((current) => {
+      const scene = cloneScene(current.scene);
+      const before = scene.nodes.length;
+      scene.nodes = scene.nodes.filter((node) => node.id !== id);
+      scene.connectors = scene.connectors.filter(
+        (connector) => connector.sourceId !== id && connector.targetId !== id
+      );
+
+      if (scene.nodes.length === before) {
+        return {};
+      }
+
+      return {
+        ...withSceneChange(current, scene),
+        selection: { nodeIds: [], connectorIds: [] }
+      };
+    }),
+  addConnector: (sourceId, targetId) => {
+    if (sourceId === targetId) {
+      return null;
+    }
+
+    const state = get();
+    const existing = state.scene.connectors.find(
+      (connector) =>
+        connector.sourceId === sourceId && connector.targetId === targetId
+    );
+    if (existing) {
+      return existing;
+    }
+
+    const connector: ConnectorModel = {
+      id: nanoid(),
+      type: 'straight',
+      sourceId,
+      targetId,
+      style: { ...defaultConnectorStyle }
+    };
+
+    set((current) => {
+      const scene = cloneScene(current.scene);
+      scene.connectors.push(connector);
+      return {
+        ...withSceneChange(current, scene),
+        selection: { nodeIds: [], connectorIds: [connector.id] },
+        tool: 'select'
+      };
+    });
+
+    return connector;
+  },
+  updateConnector: (id, patch) =>
+    set((current) => {
+      const scene = cloneScene(current.scene);
+      const connector = scene.connectors.find((item) => item.id === id);
+      if (!connector) {
+        return {};
+      }
+
+      const { style, points, ...rest } = patch;
+
+      if (points) {
+        connector.points = points.map((point) => ({ ...point }));
+      }
+      if (style) {
+        connector.style = { ...connector.style, ...style };
+      }
+
+      Object.assign(connector, rest);
+
+      return withSceneChange(current, scene);
+    }),
+  removeConnector: (id) =>
+    set((current) => {
+      const scene = cloneScene(current.scene);
+      const before = scene.connectors.length;
+      scene.connectors = scene.connectors.filter((connector) => connector.id !== id);
+      if (scene.connectors.length === before) {
+        return {};
+      }
+      return {
+        ...withSceneChange(current, scene),
+        selection: { nodeIds: [], connectorIds: [] }
+      };
+    }),
+  setSelection: (selection) => set({ selection }),
+  clearSelection: () => set({ selection: { nodeIds: [], connectorIds: [] } }),
+  toggleGrid: () => set((state) => ({ gridVisible: !state.gridVisible })),
+  toggleSnap: () => set((state) => ({ snapToGrid: !state.snapToGrid })),
+  setShowMiniMap: (value) => set({ showMiniMap: value }),
+  undo: () =>
+    set((state) => {
+      if (!state.history.past.length) {
+        return {};
+      }
+      const past = [...state.history.past];
+      const previous = past.pop()!;
+      const future = [cloneScene(state.scene), ...state.history.future];
+      return {
+        scene: cloneScene(previous),
+        history: { past, future },
+        selection: { nodeIds: [], connectorIds: [] },
+        isTransaction: false
+      };
+    }),
+  redo: () =>
+    set((state) => {
+      if (!state.history.future.length) {
+        return {};
+      }
+      const [next, ...rest] = state.history.future;
+      const past = [...state.history.past, cloneScene(state.scene)];
+      if (past.length > HISTORY_LIMIT) {
+        past.shift();
+      }
+      return {
+        scene: cloneScene(next),
+        history: { past, future: rest },
+        selection: { nodeIds: [], connectorIds: [] },
+        isTransaction: false
+      };
+    }),
+  beginTransaction: () =>
+    set((state) => {
+      if (state.isTransaction) {
+        return {};
+      }
+      const past = [...state.history.past, cloneScene(state.scene)];
+      if (past.length > HISTORY_LIMIT) {
+        past.shift();
+      }
+      return {
+        history: { past, future: [] },
+        isTransaction: true
+      };
+    }),
+  endTransaction: () =>
+    set((state) => (state.isTransaction ? { isTransaction: false } : {})),
+  setTransform: (transform) => set({ transform })
+}));
+
+export const selectScene = (state: SceneStore) => state.scene;
+export const selectNodes = (state: SceneStore) => state.scene.nodes;
+export const selectConnectors = (state: SceneStore) => state.scene.connectors;
+export const selectSelection = (state: SceneStore) => state.selection;
+export const selectTool = (state: SceneStore) => state.tool;
+export const selectGridVisible = (state: SceneStore) => state.gridVisible;
+export const selectSnapToGrid = (state: SceneStore) => state.snapToGrid;
+export const selectShowMiniMap = (state: SceneStore) => state.showMiniMap;
+export const selectTransform = (state: SceneStore) => state.transform;
+export const selectSceneBounds = (state: SceneStore, ids?: string[]) =>
+  getSceneBounds(state.scene, ids);
+export const selectNodeById = (id: string) => (state: SceneStore) =>
+  getNodeById(state.scene, id);
+export const selectCanUndo = (state: SceneStore) => state.history.past.length > 0;
+export const selectCanRedo = (state: SceneStore) => state.history.future.length > 0;

--- a/src/styles/canvas.css
+++ b/src/styles/canvas.css
@@ -1,0 +1,142 @@
+.canvas-container {
+  position: relative;
+  flex: 1;
+  border-radius: 18px;
+  background: radial-gradient(circle at top, rgba(59, 130, 246, 0.08), transparent 45%),
+    radial-gradient(circle at bottom, rgba(16, 185, 129, 0.08), transparent 35%),
+    #020617;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.05);
+  touch-action: none;
+}
+
+.canvas-container.is-panning {
+  cursor: grabbing;
+}
+
+.canvas-grid {
+  position: absolute;
+  inset: 0;
+  background-color: rgba(15, 23, 42, 0.25);
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+
+.canvas-svg {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: block;
+  pointer-events: none;
+}
+
+.canvas-svg > g,
+.canvas-svg line,
+.diagram-connector,
+.diagram-node {
+  pointer-events: all;
+}
+
+.diagram-node {
+  transition: transform 0.12s ease;
+}
+
+.diagram-node__shadow {
+  pointer-events: none;
+  filter: blur(18px);
+}
+
+.diagram-node__shape {
+  fill: rgba(15, 23, 42, 0.8);
+  transition: fill 0.2s ease, stroke 0.2s ease, opacity 0.2s ease;
+}
+
+.diagram-node__outline {
+  fill: none;
+  pointer-events: none;
+  transition: stroke 0.2s ease, stroke-width 0.2s ease;
+}
+
+.diagram-node.is-selected .diagram-node__outline {
+  filter: drop-shadow(0 0 12px rgba(96, 165, 250, 0.5));
+}
+
+.diagram-node__label {
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 1.3;
+  color: #e2e8f0;
+  background: rgba(15, 23, 42, 0.55);
+  border-radius: 14px;
+  padding: 10px 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  min-height: 24px;
+  pointer-events: none;
+  user-select: none;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.diagram-node__label.is-editing {
+  pointer-events: auto;
+  background: rgba(15, 23, 42, 0.9);
+  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.35), 0 10px 30px rgba(15, 23, 42, 0.45);
+  cursor: text;
+  user-select: text;
+  outline: none;
+}
+
+.diagram-connector {
+  pointer-events: none;
+}
+
+.diagram-connector__hit {
+  fill: none;
+  stroke: transparent;
+  pointer-events: stroke;
+}
+
+.diagram-connector__line {
+  fill: none;
+  pointer-events: stroke;
+  stroke-linecap: round;
+  transition: stroke 0.2s ease, stroke-width 0.2s ease;
+}
+
+.diagram-connector.is-selected .diagram-connector__line {
+  stroke: #60a5fa !important;
+  stroke-width: calc(var(--connector-width, 2) + 1.5);
+  filter: drop-shadow(0 0 10px rgba(96, 165, 250, 0.35));
+}
+
+.diagram-connector__label {
+  pointer-events: auto;
+  font-size: 14px;
+  color: #f8fafc;
+  background: rgba(15, 23, 42, 0.85);
+  border-radius: 12px;
+  padding: 6px 10px;
+  text-align: center;
+  box-shadow: 0 6px 20px rgba(2, 6, 23, 0.45);
+  min-height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  user-select: none;
+}
+
+.diagram-connector__label.is-editing {
+  user-select: text;
+  cursor: text;
+  outline: none;
+}
+
+.connector-pending {
+  stroke: rgba(96, 165, 250, 0.65);
+  stroke-width: 2;
+  stroke-dasharray: 6 6;
+  pointer-events: none;
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,33 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #111827;
+  color: #f9fafb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  min-width: 100vw;
+  display: flex;
+  background: radial-gradient(circle at top left, rgba(59, 130, 246, 0.15), transparent 45%),
+    radial-gradient(circle at bottom right, rgba(16, 185, 129, 0.15), transparent 40%),
+    #0f172a;
+}
+
+#root {
+  flex: 1;
+  display: flex;
+}
+
+button {
+  font: inherit;
+}
+
+svg text {
+  user-select: none;
+}

--- a/src/types/scene.ts
+++ b/src/types/scene.ts
@@ -1,0 +1,69 @@
+export type NodeKind = 'rectangle' | 'rounded-rectangle' | 'ellipse' | 'diamond';
+
+export interface Vec2 {
+  x: number;
+  y: number;
+}
+
+export interface NodeStyle {
+  fill: string;
+  stroke: string;
+  strokeWidth: number;
+  cornerRadius?: number;
+  shadow?: boolean;
+}
+
+export interface NodeModel {
+  id: string;
+  type: NodeKind;
+  position: Vec2;
+  size: { width: number; height: number };
+  rotation?: number;
+  label: string;
+  style: NodeStyle;
+}
+
+export type ConnectorKind = 'straight' | 'orthogonal';
+
+export interface ConnectorStyle {
+  stroke: string;
+  strokeWidth: number;
+  dashed?: boolean;
+  arrowStart?: 'none' | 'arrow' | 'dot';
+  arrowEnd?: 'none' | 'arrow' | 'dot';
+}
+
+export interface ConnectorModel {
+  id: string;
+  type: ConnectorKind;
+  sourceId: string;
+  targetId: string;
+  points?: Vec2[];
+  label?: string;
+  style: ConnectorStyle;
+}
+
+export interface SceneContent {
+  nodes: NodeModel[];
+  connectors: ConnectorModel[];
+}
+
+export interface SelectionState {
+  nodeIds: string[];
+  connectorIds: string[];
+}
+
+export type Tool =
+  | 'select'
+  | 'pan'
+  | 'rectangle'
+  | 'rounded-rectangle'
+  | 'ellipse'
+  | 'diamond'
+  | 'connector';
+
+export interface CanvasTransform {
+  x: number;
+  y: number;
+  scale: number;
+}

--- a/src/utils/scene.ts
+++ b/src/utils/scene.ts
@@ -1,0 +1,165 @@
+import { nanoid } from 'nanoid';
+import { CanvasTransform, NodeKind, NodeModel, SceneContent, Vec2 } from '../types/scene';
+
+export const GRID_SIZE = 32;
+
+const defaultNodeStyles: Record<NodeKind, NodeModel['style']> = {
+  rectangle: {
+    fill: '#1f2937',
+    stroke: '#3b82f6',
+    strokeWidth: 2
+  },
+  'rounded-rectangle': {
+    fill: '#1f2937',
+    stroke: '#22d3ee',
+    strokeWidth: 2,
+    cornerRadius: 16
+  },
+  ellipse: {
+    fill: '#1f2937',
+    stroke: '#f472b6',
+    strokeWidth: 2
+  },
+  diamond: {
+    fill: '#1f2937',
+    stroke: '#f59e0b',
+    strokeWidth: 2
+  }
+};
+
+const defaultNodeSizes: Record<NodeKind, { width: number; height: number }> = {
+  rectangle: { width: 220, height: 120 },
+  'rounded-rectangle': { width: 220, height: 120 },
+  ellipse: { width: 200, height: 200 },
+  diamond: { width: 220, height: 160 }
+};
+
+export const createNodeModel = (type: NodeKind, position: Vec2, label?: string): NodeModel => {
+  const size = defaultNodeSizes[type];
+  const style = defaultNodeStyles[type];
+
+  return {
+    id: nanoid(),
+    type,
+    position: { ...position },
+    size: { ...size },
+    label: label ?? defaultLabel(type),
+    style: { ...style }
+  };
+};
+
+export const getDefaultNodeSize = (type: NodeKind) => ({ ...defaultNodeSizes[type] });
+
+export const getDefaultNodeStyle = (type: NodeKind) => ({ ...defaultNodeStyles[type] });
+
+const defaultLabel = (type: NodeKind) => {
+  switch (type) {
+    case 'rectangle':
+      return 'Process';
+    case 'rounded-rectangle':
+      return 'Terminator';
+    case 'ellipse':
+      return 'Start';
+    case 'diamond':
+      return 'Decision';
+    default:
+      return 'Step';
+  }
+};
+
+export const cloneScene = (scene: SceneContent): SceneContent => ({
+  nodes: scene.nodes.map((node) => ({
+    ...node,
+    position: { ...node.position },
+    size: { ...node.size },
+    style: { ...node.style }
+  })),
+  connectors: scene.connectors.map((connector) => ({
+    ...connector,
+    points: connector.points?.map((point) => ({ ...point }))
+  }))
+});
+
+export const snapToGrid = (value: number, gridSize = GRID_SIZE): number =>
+  Math.round(value / gridSize) * gridSize;
+
+export const screenToWorld = (
+  x: number,
+  y: number,
+  transform: CanvasTransform
+): Vec2 => ({
+  x: (x - transform.x) / transform.scale,
+  y: (y - transform.y) / transform.scale
+});
+
+export const worldToScreen = (
+  point: Vec2,
+  transform: CanvasTransform
+): Vec2 => ({
+  x: point.x * transform.scale + transform.x,
+  y: point.y * transform.scale + transform.y
+});
+
+export interface Bounds {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+export const emptyBounds = (): Bounds => ({
+  minX: 0,
+  minY: 0,
+  maxX: 0,
+  maxY: 0
+});
+
+export const expandBounds = (bounds: Bounds, padding: number): Bounds => ({
+  minX: bounds.minX - padding,
+  minY: bounds.minY - padding,
+  maxX: bounds.maxX + padding,
+  maxY: bounds.maxY + padding
+});
+
+export const getSceneBounds = (scene: SceneContent, nodeIds?: string[]): Bounds | null => {
+  const nodes = nodeIds?.length
+    ? scene.nodes.filter((node) => nodeIds.includes(node.id))
+    : scene.nodes;
+
+  if (!nodes.length) {
+    return null;
+  }
+
+  const initial = {
+    minX: Number.POSITIVE_INFINITY,
+    minY: Number.POSITIVE_INFINITY,
+    maxX: Number.NEGATIVE_INFINITY,
+    maxY: Number.NEGATIVE_INFINITY
+  };
+
+  const bounds = nodes.reduce((acc, node) => {
+    acc.minX = Math.min(acc.minX, node.position.x);
+    acc.minY = Math.min(acc.minY, node.position.y);
+    acc.maxX = Math.max(acc.maxX, node.position.x + node.size.width);
+    acc.maxY = Math.max(acc.maxY, node.position.y + node.size.height);
+    return acc;
+  }, initial);
+
+  return bounds;
+};
+
+export const boundsToSize = (bounds: Bounds) => ({
+  width: bounds.maxX - bounds.minX,
+  height: bounds.maxY - bounds.minY
+});
+
+export const centerOfBounds = (bounds: Bounds): Vec2 => ({
+  x: bounds.minX + (bounds.maxX - bounds.minX) / 2,
+  y: bounds.minY + (bounds.maxY - bounds.minY) / 2
+});
+
+export const getNodeById = (scene: SceneContent, id: string): NodeModel | undefined =>
+  scene.nodes.find((node) => node.id === id);
+
+export const connectorArrowId = (type: 'arrow' | 'dot', suffix: 'start' | 'end') =>
+  `${type}-${suffix}`;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: true
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React TypeScript workspace for the schematics editor
- add an interactive canvas with pan/zoom, snapping, node creation, and connector drawing
- implement supporting UI (toolbar, inspector panel, mini map) and a zustand scene store with undo/redo
- fix node and connector update helpers so partial style edits merge with existing values instead of overwriting them

## Testing
- npm install *(fails: 403 Forbidden fetching registry packages)*
- npm run build *(fails: vite not found because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_b_68cce3067340832d9c97dbc3614be403