### PR TITLE
Support draggable connector shaping

### DIFF
--- a/src/styles/canvas.css
+++ b/src/styles/canvas.css
@@ -134,6 +134,25 @@
   outline: none;
 }
 
+.diagram-connector__handle {
+  pointer-events: all;
+  fill: rgba(15, 23, 42, 0.9);
+  stroke: #60a5fa;
+  stroke-width: 2;
+  cursor: grab;
+  transition: transform 0.15s ease, fill 0.2s ease, stroke 0.2s ease;
+}
+
+.diagram-connector__handle:hover {
+  transform: scale(1.08);
+  fill: rgba(30, 41, 59, 0.95);
+}
+
+.diagram-connector__handle:active {
+  cursor: grabbing;
+  transform: scale(0.95);
+}
+
 .connector-pending {
   stroke: rgba(96, 165, 250, 0.65);
   stroke-width: 2;

--- a/src/utils/connector.ts
+++ b/src/utils/connector.ts
@@ -1,0 +1,199 @@
+import { ConnectorModel, NodeModel, Vec2 } from '../types/scene';
+
+const EPSILON = 1e-6;
+
+export const getNodeCenter = (node: NodeModel): Vec2 => ({
+  x: node.position.x + node.size.width / 2,
+  y: node.position.y + node.size.height / 2
+});
+
+const getRectangleAnchor = (center: Vec2, halfWidth: number, halfHeight: number, toward: Vec2): Vec2 => {
+  const dx = toward.x - center.x;
+  const dy = toward.y - center.y;
+
+  if (Math.abs(dx) < EPSILON && Math.abs(dy) < EPSILON) {
+    return { ...center };
+  }
+
+  const scaleX = Math.abs(dx) < EPSILON ? Number.POSITIVE_INFINITY : halfWidth / Math.abs(dx);
+  const scaleY = Math.abs(dy) < EPSILON ? Number.POSITIVE_INFINITY : halfHeight / Math.abs(dy);
+  const scale = Math.min(scaleX, scaleY);
+
+  return {
+    x: center.x + dx * scale,
+    y: center.y + dy * scale
+  };
+};
+
+const getEllipseAnchor = (center: Vec2, radiusX: number, radiusY: number, toward: Vec2): Vec2 => {
+  const dx = toward.x - center.x;
+  const dy = toward.y - center.y;
+
+  if (Math.abs(dx) < EPSILON && Math.abs(dy) < EPSILON) {
+    return { ...center };
+  }
+
+  const denom = Math.sqrt((dx * dx) / (radiusX * radiusX) + (dy * dy) / (radiusY * radiusY));
+
+  if (denom < EPSILON) {
+    return { ...center };
+  }
+
+  const scale = 1 / denom;
+
+  return {
+    x: center.x + dx * scale,
+    y: center.y + dy * scale
+  };
+};
+
+const getDiamondAnchor = (center: Vec2, halfWidth: number, halfHeight: number, toward: Vec2): Vec2 => {
+  const dx = toward.x - center.x;
+  const dy = toward.y - center.y;
+
+  if (Math.abs(dx) < EPSILON && Math.abs(dy) < EPSILON) {
+    return { ...center };
+  }
+
+  const denom = Math.abs(dx) / halfWidth + Math.abs(dy) / halfHeight;
+
+  if (denom < EPSILON) {
+    return { ...center };
+  }
+
+  const scale = 1 / denom;
+
+  return {
+    x: center.x + dx * scale,
+    y: center.y + dy * scale
+  };
+};
+
+export const getConnectorAnchor = (node: NodeModel, toward: Vec2): Vec2 => {
+  const center = getNodeCenter(node);
+  const halfWidth = node.size.width / 2;
+  const halfHeight = node.size.height / 2;
+
+  switch (node.type) {
+    case 'ellipse':
+      return getEllipseAnchor(center, halfWidth, halfHeight, toward);
+    case 'diamond':
+      return getDiamondAnchor(center, halfWidth, halfHeight, toward);
+    default:
+      return getRectangleAnchor(center, halfWidth, halfHeight, toward);
+  }
+};
+
+export interface ConnectorPath {
+  start: Vec2;
+  end: Vec2;
+  waypoints: Vec2[];
+  points: Vec2[];
+}
+
+export const getConnectorPath = (
+  connector: ConnectorModel,
+  source: NodeModel,
+  target: NodeModel
+): ConnectorPath => {
+  const waypoints = connector.points?.map((point) => ({ ...point })) ?? [];
+  const targetReference = waypoints.length ? waypoints[0] : getNodeCenter(target);
+  const sourceReference = waypoints.length
+    ? waypoints[waypoints.length - 1]
+    : getNodeCenter(source);
+
+  const start = getConnectorAnchor(source, targetReference);
+  const end = getConnectorAnchor(target, sourceReference);
+
+  return {
+    start,
+    end,
+    waypoints,
+    points: [start, ...waypoints, end]
+  };
+};
+
+const segmentLength = (a: Vec2, b: Vec2) => Math.hypot(b.x - a.x, b.y - a.y);
+
+export const getPolylineMidpoint = (points: Vec2[]): Vec2 => {
+  if (!points.length) {
+    return { x: 0, y: 0 };
+  }
+  if (points.length === 1) {
+    return { ...points[0] };
+  }
+
+  const totalLength = points.slice(1).reduce((sum, point, index) => {
+    const previous = points[index];
+    return sum + segmentLength(previous, point);
+  }, 0);
+
+  if (totalLength < EPSILON) {
+    return { ...points[0] };
+  }
+
+  const halfLength = totalLength / 2;
+  let accumulated = 0;
+
+  for (let i = 0; i < points.length - 1; i += 1) {
+    const start = points[i];
+    const end = points[i + 1];
+    const length = segmentLength(start, end);
+
+    if (accumulated + length >= halfLength) {
+      const t = (halfLength - accumulated) / (length || 1);
+      return {
+        x: start.x + (end.x - start.x) * t,
+        y: start.y + (end.y - start.y) * t
+      };
+    }
+
+    accumulated += length;
+  }
+
+  return { ...points[points.length - 1] };
+};
+
+interface ClosestPointResult {
+  index: number;
+  point: Vec2;
+}
+
+export const findClosestPointOnPolyline = (point: Vec2, polyline: Vec2[]): ClosestPointResult => {
+  if (polyline.length < 2) {
+    return { index: 0, point: polyline[0] ? { ...polyline[0] } : { ...point } };
+  }
+
+  let closestIndex = 0;
+  let closestPoint = polyline[0];
+  let closestDistance = Number.POSITIVE_INFINITY;
+
+  for (let i = 0; i < polyline.length - 1; i += 1) {
+    const start = polyline[i];
+    const end = polyline[i + 1];
+    const dx = end.x - start.x;
+    const dy = end.y - start.y;
+    const lengthSquared = dx * dx + dy * dy;
+
+    let t = 0;
+    if (lengthSquared > EPSILON) {
+      t = ((point.x - start.x) * dx + (point.y - start.y) * dy) / lengthSquared;
+      t = Math.max(0, Math.min(1, t));
+    }
+
+    const projected = {
+      x: start.x + dx * t,
+      y: start.y + dy * t
+    };
+
+    const distanceSquared = (projected.x - point.x) ** 2 + (projected.y - point.y) ** 2;
+
+    if (distanceSquared < closestDistance) {
+      closestDistance = distanceSquared;
+      closestIndex = i;
+      closestPoint = projected;
+    }
+  }
+
+  return { index: closestIndex, point: closestPoint };
+};


### PR DESCRIPTION
## Summary
- compute connector anchors and geometry helpers to place endpoints on node perimeters
- update the canvas to support dragging connector waypoints and cancel drags with Escape
- render connector handles with styling so selected connectors can be reshaped directly on the canvas

## Testing
- npm run build *(fails: vite not found in offline environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cd536cb12c832daf72df5dee1a0357