### PR TITLE
Add selection toolbar and inline text editing

### DIFF
--- a/src/components/InlineTextEditor.tsx
+++ b/src/components/InlineTextEditor.tsx
@@ -1,0 +1,129 @@
+import React, {
+  ForwardedRef,
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState
+} from 'react';
+import { NodeModel } from '../types/scene';
+import '../styles/selection-toolbar.css';
+
+interface InlineTextEditorProps {
+  node: NodeModel;
+  bounds: { x: number; y: number; width: number; height: number } | null;
+  isEditing: boolean;
+  scale: number;
+  onCommit: (value: string) => void;
+  onCancel: () => void;
+}
+
+export interface InlineTextEditorHandle {
+  commit: () => void;
+  cancel: () => void;
+}
+
+const InlineTextEditorComponent = (
+  { node, bounds, isEditing, scale, onCommit, onCancel }: InlineTextEditorProps,
+  ref: ForwardedRef<InlineTextEditorHandle>
+) => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [value, setValue] = useState(node.text);
+
+  useEffect(() => {
+    if (isEditing) {
+      setValue(node.text);
+    }
+  }, [isEditing, node.text]);
+
+  useEffect(() => {
+    if (!isEditing) {
+      return;
+    }
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      return;
+    }
+    const frame = requestAnimationFrame(() => {
+      textarea.focus();
+      textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [isEditing]);
+
+  if (!isEditing || !bounds) {
+    return null;
+  }
+
+  const padding = 10 * scale;
+  const borderRadius = 14 * scale;
+
+  const style: React.CSSProperties = {
+    position: 'absolute',
+    left: bounds.x,
+    top: bounds.y,
+    width: bounds.width,
+    height: bounds.height,
+    padding: `${padding}px`,
+    fontSize: node.fontSize * scale,
+    fontWeight: node.fontWeight,
+    lineHeight: 1.3,
+    color: '#f8fafc',
+    background: 'rgba(15, 23, 42, 0.92)',
+    borderRadius,
+    border: `${1.2 * scale}px solid rgba(148, 163, 184, 0.5)`,
+    boxShadow: `0 ${18 * scale}px ${44 * scale}px rgba(2, 6, 23, 0.45)`,
+    resize: 'none',
+    outline: 'none',
+    whiteSpace: 'pre-wrap',
+    overflowWrap: 'break-word',
+    textAlign: node.textAlign,
+    transformOrigin: 'top left',
+    backgroundClip: 'padding-box'
+  };
+
+  const handleCommit = () => {
+    onCommit(value);
+  };
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      commit: handleCommit,
+      cancel: onCancel
+    }),
+    [value, onCommit, onCancel]
+  );
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      handleCommit();
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      onCancel();
+    }
+  };
+
+  const handleBlur = () => {
+    handleCommit();
+  };
+
+  return (
+    <textarea
+      ref={textareaRef}
+      className="inline-text-editor"
+      style={style}
+      value={value}
+      onChange={(event) => setValue(event.target.value)}
+      onKeyDown={handleKeyDown}
+      onBlur={handleBlur}
+      spellCheck={false}
+      onPointerDown={(event) => event.stopPropagation()}
+      onWheel={(event) => event.stopPropagation()}
+    />
+  );
+};
+
+export const InlineTextEditor = forwardRef(InlineTextEditorComponent);

--- a/src/components/MiniMap.tsx
+++ b/src/components/MiniMap.tsx
@@ -123,8 +123,8 @@ export const MiniMap: React.FC<MiniMapProps> = ({ scene, transform, viewport, ca
               y={topLeft.y}
               width={projectSize(node.size.width)}
               height={projectSize(node.size.height)}
-              rx={node.type === 'ellipse' ? projectSize(node.size.width / 2) : 6}
-              ry={node.type === 'ellipse' ? projectSize(node.size.height / 2) : 6}
+              rx={node.shape === 'ellipse' ? projectSize(node.size.width / 2) : 6}
+              ry={node.shape === 'ellipse' ? projectSize(node.size.height / 2) : 6}
               fill="rgba(59, 130, 246, 0.25)"
               stroke="rgba(59, 130, 246, 0.6)"
             />

--- a/src/components/PropertiesPanel.tsx
+++ b/src/components/PropertiesPanel.tsx
@@ -11,6 +11,9 @@ export const PropertiesPanel: React.FC = () => {
   const nodes = useSceneStore(selectNodes);
   const connectors = useSceneStore(selectConnectors);
   const updateNode = useSceneStore((state) => state.updateNode);
+  const setNodeText = useSceneStore((state) => state.setNodeText);
+  const applyNodeStyles = useSceneStore((state) => state.applyNodeStyles);
+  const setNodeLink = useSceneStore((state) => state.setNodeLink);
   const updateConnector = useSceneStore((state) => state.updateConnector);
   const removeNode = useSceneStore((state) => state.removeNode);
   const removeConnector = useSceneStore((state) => state.removeConnector);
@@ -53,13 +56,13 @@ export const PropertiesPanel: React.FC = () => {
       </div>
       {selectedNode && (
         <section className="properties__section">
-          <h4>{selectedNode.type.replace('-', ' ')}</h4>
+          <h4>{selectedNode.shape.replace('-', ' ')}</h4>
           <label className="properties__field">
-            <span>Label</span>
+            <span>Text</span>
             <input
               type="text"
-              value={selectedNode.label}
-              onChange={(event) => updateNode(selectedNode.id, { label: event.target.value })}
+              value={selectedNode.text}
+              onChange={(event) => setNodeText(selectedNode.id, event.target.value)}
             />
           </label>
           <div className="properties__grid">
@@ -99,16 +102,20 @@ export const PropertiesPanel: React.FC = () => {
               <span>Fill</span>
               <input
                 type="color"
-                value={selectedNode.style.fill}
-                onChange={(event) => updateNode(selectedNode.id, { style: { fill: event.target.value } })}
+                value={selectedNode.fill}
+                onChange={(event) =>
+                  applyNodeStyles([selectedNode.id], { fill: event.target.value })
+                }
               />
             </label>
             <label className="properties__field">
               <span>Stroke</span>
               <input
                 type="color"
-                value={selectedNode.style.stroke}
-                onChange={(event) => updateNode(selectedNode.id, { style: { stroke: event.target.value } })}
+                value={selectedNode.stroke.color}
+                onChange={(event) =>
+                  applyNodeStyles([selectedNode.id], { strokeColor: event.target.value })
+                }
               />
             </label>
           </div>
@@ -118,10 +125,19 @@ export const PropertiesPanel: React.FC = () => {
               type="number"
               min={1}
               max={12}
-              value={selectedNode.style.strokeWidth}
+              value={selectedNode.stroke.width}
               onChange={(event) =>
-                updateNode(selectedNode.id, { style: { strokeWidth: Number(event.target.value) } })
+                applyNodeStyles([selectedNode.id], { strokeWidth: Number(event.target.value) })
               }
+            />
+          </label>
+          <label className="properties__field">
+            <span>Link</span>
+            <input
+              type="url"
+              placeholder="https://example.com"
+              value={selectedNode.link?.url ?? ''}
+              onChange={(event) => setNodeLink(selectedNode.id, event.target.value)}
             />
           </label>
           <button

--- a/src/components/SelectionToolbar.tsx
+++ b/src/components/SelectionToolbar.tsx
@@ -1,0 +1,491 @@
+import React, {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
+import { NodeModel, NodeKind, TextAlign } from '../types/scene';
+import { useCommands } from '../state/commands';
+import '../styles/selection-toolbar.css';
+
+const FONT_SIZE_MIN = 8;
+const FONT_SIZE_MAX = 200;
+const STROKE_MIN = 0;
+const STROKE_MAX = 20;
+const TOOLBAR_GAP = 12;
+
+const shapeOptions: Array<{ value: NodeKind; label: string }> = [
+  { value: 'rectangle', label: 'Rect' },
+  { value: 'rounded-rectangle', label: 'Round' },
+  { value: 'ellipse', label: 'Ellipse' },
+  { value: 'diamond', label: 'Diamond' }
+];
+
+const alignOptions: Array<{ value: TextAlign; label: string; icon: string }> = [
+  { value: 'left', label: 'Align left', icon: 'L' },
+  { value: 'center', label: 'Align center', icon: 'C' },
+  { value: 'right', label: 'Align right', icon: 'R' }
+];
+
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+const ensureProtocol = (value: string) => {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return '';
+  }
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+  return `https://${trimmed}`;
+};
+
+const isValidHttpUrl = (value: string) => {
+  if (!value) {
+    return true;
+  }
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch (error) {
+    return false;
+  }
+};
+
+export interface SelectionToolbarProps {
+  node: NodeModel;
+  nodeIds: string[];
+  anchor: { x: number; y: number; width: number; height: number } | null;
+  viewportSize: { width: number; height: number };
+  isVisible: boolean;
+  focusLinkSignal: number;
+}
+
+export const SelectionToolbar: React.FC<SelectionToolbarProps> = ({
+  node,
+  nodeIds,
+  anchor,
+  viewportSize,
+  isVisible,
+  focusLinkSignal
+}) => {
+  const commands = useCommands();
+  const toolbarRef = useRef<HTMLDivElement>(null);
+  const linkButtonRef = useRef<HTMLButtonElement>(null);
+  const linkInputRef = useRef<HTMLInputElement>(null);
+  const linkPopoverRef = useRef<HTMLDivElement>(null);
+  const previousFocusSignalRef = useRef(focusLinkSignal);
+
+  const [placement, setPlacement] = useState<'top' | 'bottom'>('top');
+  const [fontSizeValue, setFontSizeValue] = useState(node.fontSize.toString());
+  const [strokeWidthValue, setStrokeWidthValue] = useState(node.stroke.width.toString());
+  const [linkOpen, setLinkOpen] = useState(false);
+  const [linkDraft, setLinkDraft] = useState(node.link?.url ?? '');
+  const [linkError, setLinkError] = useState<string | null>(null);
+
+  const hasText = node.text.trim().length > 0;
+  const isBold = node.fontWeight >= 700;
+
+  useEffect(() => {
+    setFontSizeValue(node.fontSize.toString());
+  }, [node.fontSize]);
+
+  useEffect(() => {
+    setStrokeWidthValue(node.stroke.width.toString());
+  }, [node.stroke.width]);
+
+  useEffect(() => {
+    if (linkOpen) {
+      setLinkDraft(node.link?.url ?? '');
+      setLinkError(null);
+    }
+  }, [linkOpen, node.link?.url]);
+
+  useEffect(() => {
+    if (!isVisible) {
+      setLinkOpen(false);
+      setLinkError(null);
+    }
+  }, [isVisible]);
+
+  useEffect(() => {
+    if (focusLinkSignal !== previousFocusSignalRef.current) {
+      previousFocusSignalRef.current = focusLinkSignal;
+      if (isVisible) {
+        setLinkOpen(true);
+      }
+    }
+  }, [focusLinkSignal, isVisible]);
+
+  useEffect(() => {
+    if (!linkOpen) {
+      return;
+    }
+    const frame = requestAnimationFrame(() => {
+      linkInputRef.current?.focus();
+      linkInputRef.current?.select();
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [linkOpen]);
+
+  useEffect(() => {
+    if (!linkOpen) {
+      return;
+    }
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (
+        linkPopoverRef.current &&
+        !linkPopoverRef.current.contains(target) &&
+        linkButtonRef.current &&
+        !linkButtonRef.current.contains(target)
+      ) {
+        setLinkOpen(false);
+        setLinkError(null);
+      }
+    };
+    document.addEventListener('mousedown', handlePointerDown);
+    return () => document.removeEventListener('mousedown', handlePointerDown);
+  }, [linkOpen]);
+
+  useEffect(() => {
+    setPlacement('top');
+  }, [anchor?.x, anchor?.y, anchor?.width, anchor?.height]);
+
+  useLayoutEffect(() => {
+    if (!anchor || !isVisible || !toolbarRef.current) {
+      return;
+    }
+    const element = toolbarRef.current;
+    const height = element.offsetHeight;
+    const topSpace = anchor.y - TOOLBAR_GAP - height;
+    const bottomPosition = anchor.y + anchor.height + TOOLBAR_GAP;
+    const bottomSpace = viewportSize.height - (bottomPosition + height);
+
+    if (placement === 'top' && topSpace < 8 && bottomSpace > topSpace) {
+      setPlacement('bottom');
+    } else if (placement === 'bottom' && bottomSpace < 8 && topSpace > bottomSpace) {
+      setPlacement('top');
+    }
+  }, [anchor, viewportSize.height, placement, isVisible]);
+
+  const style = useMemo(() => {
+    if (!anchor) {
+      return {} as React.CSSProperties;
+    }
+    const left = anchor.x + anchor.width / 2;
+    if (placement === 'top') {
+      return {
+        left,
+        top: anchor.y - TOOLBAR_GAP,
+        transform: 'translate(-50%, -100%)'
+      } as React.CSSProperties;
+    }
+    return {
+      left,
+      top: anchor.y + anchor.height + TOOLBAR_GAP,
+      transform: 'translate(-50%, 0)'
+    } as React.CSSProperties;
+  }, [anchor, placement]);
+
+  if (!isVisible || !anchor) {
+    return null;
+  }
+
+  const handleToggleBold = () => {
+    commands.applyStyles(nodeIds, { fontWeight: isBold ? 600 : 700 });
+  };
+
+  const handleAlign = (value: TextAlign) => {
+    commands.applyStyles(nodeIds, { textAlign: value });
+  };
+
+  const commitFontSize = (value: number) => {
+    const next = clamp(value, FONT_SIZE_MIN, FONT_SIZE_MAX);
+    setFontSizeValue(next.toString());
+    commands.applyStyles(nodeIds, { fontSize: next });
+  };
+
+  const commitStrokeWidth = (value: number) => {
+    const next = clamp(value, STROKE_MIN, STROKE_MAX);
+    setStrokeWidthValue(next.toString());
+    commands.applyStyles(nodeIds, { strokeWidth: next });
+  };
+
+  const handleFontSizeBlur = () => {
+    const parsed = Number(fontSizeValue);
+    if (Number.isFinite(parsed)) {
+      commitFontSize(parsed);
+    } else {
+      setFontSizeValue(node.fontSize.toString());
+    }
+  };
+
+  const handleFontSizeKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      handleFontSizeBlur();
+    }
+  };
+
+  const handleStrokeWidthBlur = () => {
+    const parsed = Number(strokeWidthValue);
+    if (Number.isFinite(parsed)) {
+      commitStrokeWidth(parsed);
+    } else {
+      setStrokeWidthValue(node.stroke.width.toString());
+    }
+  };
+
+  const handleStrokeWidthKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      handleStrokeWidthBlur();
+    }
+  };
+
+  const adjustFontSize = (delta: number) => {
+    commitFontSize(node.fontSize + delta);
+  };
+
+  const adjustStrokeWidth = (delta: number) => {
+    commitStrokeWidth(node.stroke.width + delta);
+  };
+
+  const handleShapeChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    commands.setShape(nodeIds, event.target.value as NodeKind);
+  };
+
+  const handleFillChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    commands.applyStyles(nodeIds, { fill: event.target.value });
+  };
+
+  const handleStrokeColorChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    commands.applyStyles(nodeIds, { strokeColor: event.target.value });
+  };
+
+  const handleLinkApply = () => {
+    const normalized = ensureProtocol(linkDraft);
+    if (!normalized) {
+      commands.setLink(node.id, null);
+      setLinkOpen(false);
+      setLinkError(null);
+      return;
+    }
+
+    if (!isValidHttpUrl(normalized)) {
+      setLinkError('Enter a valid http(s) URL');
+      return;
+    }
+
+    commands.setLink(node.id, normalized);
+    setLinkError(null);
+    setLinkOpen(false);
+  };
+
+  const handleLinkRemove = () => {
+    commands.setLink(node.id, null);
+    setLinkDraft('');
+    setLinkError(null);
+    setLinkOpen(false);
+  };
+
+  const handleLinkKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      handleLinkApply();
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      setLinkOpen(false);
+      setLinkError(null);
+    }
+  };
+
+  const handleLinkBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    const nextTarget = event.relatedTarget as HTMLElement | null;
+    if (nextTarget && linkPopoverRef.current?.contains(nextTarget)) {
+      return;
+    }
+    handleLinkApply();
+  };
+
+  const handleOpenLink = () => {
+    if (!node.link?.url) {
+      return;
+    }
+    window.open(node.link.url, '_blank', 'noopener');
+  };
+
+  const textDisabled = !hasText;
+  const strokeWidthDisabled = !node.stroke.color;
+
+  return (
+    <div
+      ref={toolbarRef}
+      className="selection-toolbar"
+      style={style}
+      data-placement={placement}
+    >
+      <div className="selection-toolbar__group">
+        <button
+          type="button"
+          className={`selection-toolbar__button ${isBold ? 'is-active' : ''}`}
+          onClick={handleToggleBold}
+          disabled={textDisabled}
+          title="Bold (Cmd/Ctrl+B)"
+        >
+          <span className="selection-toolbar__icon">B</span>
+        </button>
+        <div className="selection-toolbar__segmented" role="group" aria-label="Text alignment">
+          {alignOptions.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              className={`selection-toolbar__button ${
+                node.textAlign === option.value ? 'is-active' : ''
+              }`}
+              onClick={() => handleAlign(option.value)}
+              disabled={textDisabled}
+              title={`${option.label} (Cmd/Ctrl+Shift+${option.icon})`}
+            >
+              <span className="selection-toolbar__icon" aria-hidden>
+                {option.icon}
+              </span>
+            </button>
+          ))}
+        </div>
+        <div className="selection-toolbar__size-control">
+          <button
+            type="button"
+            onClick={() => adjustFontSize(-1)}
+            disabled={textDisabled}
+            className="selection-toolbar__button"
+            title="Decrease size (Cmd/Ctrl+-)"
+          >
+            −
+          </button>
+          <input
+            type="number"
+            className="selection-toolbar__input"
+            value={fontSizeValue}
+            min={FONT_SIZE_MIN}
+            max={FONT_SIZE_MAX}
+            onChange={(event) => setFontSizeValue(event.target.value)}
+            onBlur={handleFontSizeBlur}
+            onKeyDown={handleFontSizeKeyDown}
+            disabled={textDisabled}
+            aria-label="Font size"
+          />
+          <button
+            type="button"
+            onClick={() => adjustFontSize(1)}
+            disabled={textDisabled}
+            className="selection-toolbar__button"
+            title="Increase size (Cmd/Ctrl+=)"
+          >
+            +
+          </button>
+        </div>
+      </div>
+      <div className="selection-toolbar__group">
+        <label className="selection-toolbar__swatch" title="Fill color">
+          <span className="selection-toolbar__swatch-indicator">Fill</span>
+          <input type="color" value={node.fill} onChange={handleFillChange} />
+        </label>
+        <label className="selection-toolbar__swatch" title="Stroke color">
+          <span className="selection-toolbar__swatch-indicator">Stroke</span>
+          <input type="color" value={node.stroke.color} onChange={handleStrokeColorChange} />
+        </label>
+        <div className="selection-toolbar__size-control">
+          <button
+            type="button"
+            onClick={() => adjustStrokeWidth(-1)}
+            disabled={strokeWidthDisabled}
+            className="selection-toolbar__button"
+            title="Thinner stroke"
+          >
+            −
+          </button>
+          <input
+            type="number"
+            className="selection-toolbar__input"
+            value={strokeWidthValue}
+            min={STROKE_MIN}
+            max={STROKE_MAX}
+            onChange={(event) => setStrokeWidthValue(event.target.value)}
+            onBlur={handleStrokeWidthBlur}
+            onKeyDown={handleStrokeWidthKeyDown}
+            disabled={strokeWidthDisabled}
+            aria-label="Stroke width"
+          />
+          <button
+            type="button"
+            onClick={() => adjustStrokeWidth(1)}
+            disabled={strokeWidthDisabled}
+            className="selection-toolbar__button"
+            title="Thicker stroke"
+          >
+            +
+          </button>
+        </div>
+      </div>
+      <div className="selection-toolbar__group">
+        <label className="selection-toolbar__shape" title="Change shape">
+          <span>Shape</span>
+          <select value={node.shape} onChange={handleShapeChange}>
+            {shapeOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <div className="selection-toolbar__group selection-toolbar__group--link">
+        <button
+          type="button"
+          ref={linkButtonRef}
+          className={`selection-toolbar__button ${linkOpen ? 'is-active' : ''}`}
+          onClick={() => setLinkOpen((prev) => !prev)}
+          title="Link (Cmd/Ctrl+K)"
+        >
+          🔗
+        </button>
+        {node.link?.url && (
+          <button
+            type="button"
+            className="selection-toolbar__button"
+            onClick={handleOpenLink}
+            title="Open link"
+          >
+            Open
+          </button>
+        )}
+      </div>
+      {linkOpen && (
+        <div className="selection-toolbar__link-popover" ref={linkPopoverRef}>
+          <input
+            ref={linkInputRef}
+            type="url"
+            value={linkDraft}
+            placeholder="https://example.com"
+            onChange={(event) => setLinkDraft(event.target.value)}
+            onKeyDown={handleLinkKeyDown}
+            onBlur={handleLinkBlur}
+          />
+          <div className="selection-toolbar__link-actions">
+            <button type="button" onClick={handleLinkApply}>
+              Apply
+            </button>
+            <button type="button" onClick={handleLinkRemove} disabled={!node.link?.url && !linkDraft.trim()}>
+              Remove
+            </button>
+          </div>
+          {linkError && <div className="selection-toolbar__link-error">{linkError}</div>}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/state/commands.ts
+++ b/src/state/commands.ts
@@ -1,0 +1,52 @@
+import { useCallback } from 'react';
+import { NodeKind } from '../types/scene';
+import { NodeStylePatch, useSceneStore } from './sceneStore';
+
+interface Commands {
+  applyStyles: (nodeIds: string[], patch: NodeStylePatch) => void;
+  setText: (nodeId: string, text: string) => void;
+  setShape: (nodeIds: string[], shape: NodeKind) => void;
+  setLink: (nodeId: string, url: string | null) => void;
+}
+
+export const useCommands = (): Commands => {
+  const applyNodeStyles = useSceneStore((state) => state.applyNodeStyles);
+  const setNodeText = useSceneStore((state) => state.setNodeText);
+  const setNodeShape = useSceneStore((state) => state.setNodeShape);
+  const setNodeLink = useSceneStore((state) => state.setNodeLink);
+
+  const applyStyles = useCallback(
+    (nodeIds: string[], patch: NodeStylePatch) => {
+      applyNodeStyles(nodeIds, patch);
+    },
+    [applyNodeStyles]
+  );
+
+  const setText = useCallback(
+    (nodeId: string, text: string) => {
+      setNodeText(nodeId, text);
+    },
+    [setNodeText]
+  );
+
+  const setShape = useCallback(
+    (nodeIds: string[], shape: NodeKind) => {
+      setNodeShape(nodeIds, shape);
+    },
+    [setNodeShape]
+  );
+
+  const setLink = useCallback(
+    (nodeId: string, url: string | null) => {
+      setNodeLink(nodeId, url);
+    },
+    [setNodeLink]
+  );
+
+  return {
+    applyStyles,
+    setText,
+    setShape,
+    setLink
+  };
+};

--- a/src/styles/canvas.css
+++ b/src/styles/canvas.css
@@ -70,23 +70,33 @@
   background: rgba(15, 23, 42, 0.55);
   border-radius: 14px;
   padding: 10px 14px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
   min-height: 24px;
   pointer-events: none;
   user-select: none;
-  transition: background 0.2s ease, box-shadow 0.2s ease;
+  white-space: pre-wrap;
+  word-break: break-word;
+  display: block;
+  width: 100%;
+  height: 100%;
+  transition: background 0.2s ease, opacity 0.2s ease;
 }
 
 .diagram-node__label.is-editing {
-  pointer-events: auto;
-  background: rgba(15, 23, 42, 0.9);
-  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.35), 0 10px 30px rgba(15, 23, 42, 0.45);
-  cursor: text;
-  user-select: text;
-  outline: none;
+  opacity: 0.25;
+}
+
+.diagram-node__link-chip {
+  font-size: 12px;
+  line-height: 1;
+  color: #bae6fd;
+  background: rgba(15, 23, 42, 0.8);
+  border-radius: 999px;
+  padding: 6px 10px;
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 18px rgba(2, 6, 23, 0.35);
 }
 
 .diagram-node__connector-handles {

--- a/src/styles/selection-toolbar.css
+++ b/src/styles/selection-toolbar.css
@@ -1,0 +1,227 @@
+.selection-toolbar {
+  position: absolute;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 10px 14px;
+  background: rgba(15, 23, 42, 0.92);
+  border-radius: 14px;
+  box-shadow: 0 18px 44px rgba(2, 6, 23, 0.55), 0 0 0 1px rgba(148, 163, 184, 0.25);
+  pointer-events: auto;
+  user-select: none;
+  backdrop-filter: blur(12px);
+  color: #f8fafc;
+  min-width: 320px;
+}
+
+.selection-toolbar__group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.selection-toolbar__group + .selection-toolbar__group {
+  border-left: 1px solid rgba(148, 163, 184, 0.16);
+  padding-left: 12px;
+}
+
+.selection-toolbar__button {
+  appearance: none;
+  border: none;
+  background: rgba(30, 41, 59, 0.65);
+  color: inherit;
+  padding: 6px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.15s ease;
+}
+
+.selection-toolbar__button:hover:not(:disabled) {
+  background: rgba(59, 130, 246, 0.2);
+}
+
+.selection-toolbar__button:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
+.selection-toolbar__button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.selection-toolbar__button.is-active {
+  background: rgba(59, 130, 246, 0.35);
+  color: #e0f2fe;
+}
+
+.selection-toolbar__icon {
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.selection-toolbar__segmented {
+  display: inline-flex;
+  border-radius: 10px;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.selection-toolbar__segmented .selection-toolbar__button {
+  border-radius: 0;
+  background: transparent;
+}
+
+.selection-toolbar__segmented .selection-toolbar__button + .selection-toolbar__button {
+  border-left: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.selection-toolbar__size-control {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  overflow: hidden;
+}
+
+.selection-toolbar__size-control .selection-toolbar__button {
+  border-radius: 0;
+  background: transparent;
+  width: 32px;
+  height: 28px;
+  padding: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.selection-toolbar__input {
+  width: 56px;
+  border: none;
+  background: rgba(15, 23, 42, 0.9);
+  color: inherit;
+  text-align: center;
+  font-size: 13px;
+  outline: none;
+}
+
+.selection-toolbar__swatch {
+  position: relative;
+  display: inline-flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: center;
+  font-size: 12px;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.selection-toolbar__swatch-indicator {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.selection-toolbar__swatch input[type='color'] {
+  appearance: none;
+  border: none;
+  width: 32px;
+  height: 24px;
+  border-radius: 6px;
+  background: none;
+  cursor: pointer;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
+}
+
+.selection-toolbar__swatch input[type='color']::-webkit-color-swatch {
+  border-radius: 6px;
+  border: none;
+}
+
+.selection-toolbar__swatch input[type='color']::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.selection-toolbar__shape {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.selection-toolbar__shape select {
+  background: rgba(15, 23, 42, 0.9);
+  color: inherit;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 8px;
+  padding: 4px 8px;
+  font-size: 13px;
+}
+
+.selection-toolbar__group--link {
+  position: relative;
+}
+
+.selection-toolbar__link-popover {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  min-width: 240px;
+  background: rgba(15, 23, 42, 0.95);
+  border-radius: 12px;
+  padding: 12px;
+  box-shadow: 0 16px 34px rgba(2, 6, 23, 0.55), 0 0 0 1px rgba(148, 163, 184, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  z-index: 45;
+}
+
+.selection-toolbar__link-popover input {
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: rgba(15, 23, 42, 0.9);
+  color: inherit;
+  font-size: 13px;
+  outline: none;
+}
+
+.selection-toolbar__link-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.selection-toolbar__link-actions button {
+  border: none;
+  background: rgba(59, 130, 246, 0.35);
+  color: #e0f2fe;
+  border-radius: 8px;
+  padding: 6px 10px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  transition: background 0.2s ease;
+}
+
+.selection-toolbar__link-actions button:hover:not(:disabled) {
+  background: rgba(59, 130, 246, 0.45);
+}
+
+.selection-toolbar__link-actions button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.selection-toolbar__link-error {
+  font-size: 12px;
+  color: #fca5a5;
+}
+
+.inline-text-editor {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: rgba(15, 23, 42, 0.9);
+  color: #f8fafc;
+}

--- a/src/types/scene.ts
+++ b/src/types/scene.ts
@@ -1,26 +1,39 @@
-export type NodeKind = 'rectangle' | 'rounded-rectangle' | 'ellipse' | 'diamond';
+export type NodeShape = 'rectangle' | 'rounded-rectangle' | 'ellipse' | 'diamond';
+export type NodeKind = NodeShape;
 
 export interface Vec2 {
   x: number;
   y: number;
 }
 
-export interface NodeStyle {
-  fill: string;
-  stroke: string;
-  strokeWidth: number;
-  cornerRadius?: number;
-  shadow?: boolean;
+export type TextAlign = 'left' | 'center' | 'right';
+
+export type NodeFontWeight = 400 | 600 | 700;
+
+export interface NodeStroke {
+  color: string;
+  width: number;
+}
+
+export interface NodeLink {
+  url: string;
 }
 
 export interface NodeModel {
   id: string;
-  type: NodeKind;
+  shape: NodeShape;
   position: Vec2;
   size: { width: number; height: number };
   rotation?: number;
-  label: string;
-  style: NodeStyle;
+  text: string;
+  textAlign: TextAlign;
+  fontSize: number;
+  fontWeight: NodeFontWeight;
+  fill: string;
+  stroke: NodeStroke;
+  cornerRadius?: number;
+  link?: NodeLink;
+  shadow?: boolean;
 }
 
 export type ConnectorKind = 'straight' | 'orthogonal';

--- a/src/utils/connector.ts
+++ b/src/utils/connector.ts
@@ -74,7 +74,7 @@ export const getConnectorAnchor = (node: NodeModel, toward: Vec2): Vec2 => {
   const halfWidth = node.size.width / 2;
   const halfHeight = node.size.height / 2;
 
-  switch (node.type) {
+  switch (node.shape) {
     case 'ellipse':
       return getEllipseAnchor(center, halfWidth, halfHeight, toward);
     case 'diamond':

--- a/src/utils/scene.ts
+++ b/src/utils/scene.ts
@@ -1,9 +1,18 @@
 import { nanoid } from 'nanoid';
-import { CanvasTransform, NodeKind, NodeModel, SceneContent, Vec2 } from '../types/scene';
+import {
+  CanvasTransform,
+  NodeKind,
+  NodeModel,
+  SceneContent,
+  Vec2
+} from '../types/scene';
 
 export const GRID_SIZE = 32;
 
-const defaultNodeStyles: Record<NodeKind, NodeModel['style']> = {
+const defaultNodeAppearance: Record<
+  NodeKind,
+  { fill: string; stroke: string; strokeWidth: number; cornerRadius?: number }
+> = {
   rectangle: {
     fill: '#1f2937',
     stroke: '#3b82f6',
@@ -34,23 +43,26 @@ const defaultNodeSizes: Record<NodeKind, { width: number; height: number }> = {
   diamond: { width: 220, height: 160 }
 };
 
-export const createNodeModel = (type: NodeKind, position: Vec2, label?: string): NodeModel => {
-  const size = defaultNodeSizes[type];
-  const style = defaultNodeStyles[type];
+export const createNodeModel = (shape: NodeKind, position: Vec2, text?: string): NodeModel => {
+  const size = defaultNodeSizes[shape];
+  const appearance = defaultNodeAppearance[shape];
 
   return {
     id: nanoid(),
-    type,
+    shape,
     position: { ...position },
     size: { ...size },
-    label: label ?? defaultLabel(type),
-    style: { ...style }
+    text: text ?? defaultLabel(shape),
+    textAlign: 'center',
+    fontSize: 18,
+    fontWeight: 600,
+    fill: appearance.fill,
+    stroke: { color: appearance.stroke, width: appearance.strokeWidth },
+    cornerRadius: appearance.cornerRadius
   };
 };
 
-export const getDefaultNodeSize = (type: NodeKind) => ({ ...defaultNodeSizes[type] });
-
-export const getDefaultNodeStyle = (type: NodeKind) => ({ ...defaultNodeStyles[type] });
+export const getDefaultNodeSize = (shape: NodeKind) => ({ ...defaultNodeSizes[shape] });
 
 const defaultLabel = (type: NodeKind) => {
   switch (type) {
@@ -72,7 +84,8 @@ export const cloneScene = (scene: SceneContent): SceneContent => ({
     ...node,
     position: { ...node.position },
     size: { ...node.size },
-    style: { ...node.style }
+    stroke: { ...node.stroke },
+    link: node.link ? { ...node.link } : undefined
   })),
   connectors: scene.connectors.map((connector) => ({
     ...connector,


### PR DESCRIPTION
## Summary
- add a floating selection toolbar with formatting, color, shape, and link controls that anchors to the active node
- support inline text editing with keyboard shortcuts and commit/cancel behavior similar to Figma
- extend scene store commands to apply styles, manage shapes and links, and persist editing state

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68ce1b8a1c08832d945ea558aa1765cd