### PR TITLE
feat: add smart snapping system

### DIFF
--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -4,6 +4,7 @@ import {
   selectCanRedo,
   selectCanUndo,
   selectGridVisible,
+  selectSnapSettings,
   selectShowMiniMap,
   selectTool,
   selectTransform,
@@ -34,7 +35,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({ canvasRef }) => {
   const canRedo = useSceneStore(selectCanRedo);
   const gridVisible = useSceneStore(selectGridVisible);
   const toggleGrid = useSceneStore((state) => state.toggleGrid);
-  const snapToGrid = useSceneStore((state) => state.snapToGrid);
+  const snapSettings = useSceneStore(selectSnapSettings);
   const toggleSnap = useSceneStore((state) => state.toggleSnap);
   const showMiniMap = useSceneStore(selectShowMiniMap);
   const setShowMiniMap = useSceneStore((state) => state.setShowMiniMap);
@@ -119,9 +120,9 @@ export const Toolbar: React.FC<ToolbarProps> = ({ canvasRef }) => {
         </button>
         <button
           type="button"
-          className={`toolbar__button ${snapToGrid ? 'is-active' : ''}`}
+          className={`toolbar__button ${snapSettings.enabled ? 'is-active' : ''}`}
           onClick={toggleSnap}
-          title="Snap to Grid"
+          title="Toggle Smart Snap"
         >
           Snap
         </button>

--- a/src/styles/canvas.css
+++ b/src/styles/canvas.css
@@ -199,6 +199,113 @@
   fill: rgba(37, 99, 235, 0.3);
 }
 
+.canvas-overlays {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 4;
+  font-family: inherit;
+}
+
+.canvas-guides {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.canvas-guide-line {
+  stroke: rgba(192, 132, 252, 0.95);
+  stroke-width: 1;
+  shape-rendering: crispEdges;
+}
+
+.canvas-guide-line--center {
+  stroke: rgba(129, 140, 248, 0.95);
+}
+
+.distance-badge {
+  position: absolute;
+  pointer-events: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #f8fafc;
+  background: rgba(79, 70, 229, 0.92);
+  border-radius: 6px;
+  box-shadow: 0 6px 20px rgba(15, 23, 42, 0.35);
+  text-shadow: 0 0 6px rgba(15, 23, 42, 0.65);
+  opacity: 0.94;
+  transition: opacity 0.18s ease;
+}
+
+.distance-badge--x.distance-badge--negative {
+  transform: translate(-100%, -50%);
+}
+
+.distance-badge--x.distance-badge--positive {
+  transform: translate(0%, -50%);
+}
+
+.distance-badge--y.distance-badge--negative {
+  transform: translate(-50%, -100%);
+}
+
+.distance-badge--y.distance-badge--positive {
+  transform: translate(-50%, 0%);
+}
+
+.distance-badge__equal {
+  font-weight: 700;
+  font-size: 12px;
+}
+
+.distance-badge.is-equal {
+  background: rgba(16, 185, 129, 0.9);
+  color: #0f172a;
+}
+
+.spacing-handle {
+  position: absolute;
+  pointer-events: auto;
+  transform: translate(-50%, -50%);
+  background: rgba(236, 72, 153, 0.92);
+  color: #fff;
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 11px;
+  font-weight: 700;
+  box-shadow: 0 10px 24px rgba(236, 72, 153, 0.35);
+  cursor: grab;
+  transition: transform 0.18s ease, background 0.18s ease, opacity 0.18s ease;
+}
+
+.spacing-handle:hover {
+  transform: translate(-50%, -50%) scale(1.05);
+}
+
+.spacing-handle:active {
+  transform: translate(-50%, -50%) scale(0.95);
+  cursor: grabbing;
+}
+
+.spacing-handle__label {
+  pointer-events: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.spacing-handle.is-uniform {
+  background: rgba(52, 211, 153, 0.92);
+  color: #0f172a;
+  box-shadow: 0 10px 24px rgba(45, 212, 191, 0.35);
+}
+
 .diagram-connector__endpoint:active {
   transform: scale(0.9);
 }

--- a/src/utils/snap.ts
+++ b/src/utils/snap.ts
@@ -1,0 +1,601 @@
+import { NodeModel, Vec2 } from '../types/scene';
+import { Bounds } from './scene';
+
+export interface RectInfo {
+  id: string;
+  bounds: Bounds;
+  center: Vec2;
+  size: { width: number; height: number };
+}
+
+export const getNodeRectInfo = (node: NodeModel): RectInfo => {
+  const bounds: Bounds = {
+    minX: node.position.x,
+    minY: node.position.y,
+    maxX: node.position.x + node.size.width,
+    maxY: node.position.y + node.size.height
+  };
+
+  return {
+    id: node.id,
+    bounds,
+    center: {
+      x: bounds.minX + (bounds.maxX - bounds.minX) / 2,
+      y: bounds.minY + (bounds.maxY - bounds.minY) / 2
+    },
+    size: { width: node.size.width, height: node.size.height }
+  };
+};
+
+export const translateBounds = (bounds: Bounds, delta: Vec2): Bounds => ({
+  minX: bounds.minX + delta.x,
+  minY: bounds.minY + delta.y,
+  maxX: bounds.maxX + delta.x,
+  maxY: bounds.maxY + delta.y
+});
+
+type EdgeKey = 'left' | 'right' | 'centerX' | 'top' | 'bottom' | 'centerY';
+
+export interface SnapMatchLock {
+  axis: 'x' | 'y';
+  edge: EdgeKey;
+  neighborEdge: EdgeKey;
+  type: 'center' | 'edge';
+  target: number;
+  neighborId: string | null;
+}
+
+export interface SnapMatch extends SnapMatchLock {
+  delta: number;
+  line: { start: Vec2; end: Vec2 };
+}
+
+export interface ActiveSnapMatches {
+  vertical?: SnapMatchLock;
+  horizontal?: SnapMatchLock;
+}
+
+export interface SmartGuideParams {
+  movingRect: Bounds;
+  otherRects: RectInfo[];
+  tolerance: number;
+  activeMatches?: ActiveSnapMatches;
+  centerOnly?: boolean;
+}
+
+export interface SmartGuideResult {
+  matches: {
+    vertical?: SnapMatch;
+    horizontal?: SnapMatch;
+  };
+  guides: SnapMatch[];
+}
+
+export interface DistanceBadge {
+  id: string;
+  axis: 'x' | 'y';
+  position: Vec2;
+  value: number;
+  direction: 'positive' | 'negative';
+  equal?: boolean;
+}
+
+export interface SmartSelectionHandle {
+  id: string;
+  axis: 'x' | 'y';
+  position: Vec2;
+  beforeId: string;
+  affectedIds: string[];
+  gap: number;
+  rawGap: number;
+}
+
+export interface SmartSelectionResult {
+  axis: 'x' | 'y';
+  handles: SmartSelectionHandle[];
+  isUniform: boolean;
+}
+
+const EPSILON = 0.0001;
+
+const widthOf = (bounds: Bounds) => bounds.maxX - bounds.minX;
+const heightOf = (bounds: Bounds) => bounds.maxY - bounds.minY;
+const centerXOf = (bounds: Bounds) => bounds.minX + (bounds.maxX - bounds.minX) / 2;
+const centerYOf = (bounds: Bounds) => bounds.minY + (bounds.maxY - bounds.minY) / 2;
+
+const getEdgeValue = (bounds: Bounds, edge: EdgeKey): number => {
+  switch (edge) {
+    case 'left':
+      return bounds.minX;
+    case 'right':
+      return bounds.maxX;
+    case 'centerX':
+      return centerXOf(bounds);
+    case 'top':
+      return bounds.minY;
+    case 'bottom':
+      return bounds.maxY;
+    case 'centerY':
+      return centerYOf(bounds);
+    default:
+      return 0;
+  }
+};
+
+const computeGuideLine = (
+  axis: 'x' | 'y',
+  target: number,
+  moving: Bounds,
+  neighbor?: Bounds
+): { start: Vec2; end: Vec2 } => {
+  const reference = neighbor ?? moving;
+  if (axis === 'x') {
+    const startY = Math.min(moving.minY, reference.minY);
+    const endY = Math.max(moving.maxY, reference.maxY);
+    return {
+      start: { x: target, y: startY },
+      end: { x: target, y: endY }
+    };
+  }
+  const startX = Math.min(moving.minX, reference.minX);
+  const endX = Math.max(moving.maxX, reference.maxX);
+  return {
+    start: { x: startX, y: target },
+    end: { x: endX, y: target }
+  };
+};
+
+const maintainLock = (
+  axis: 'x' | 'y',
+  movingRect: Bounds,
+  otherRects: RectInfo[],
+  tolerance: number,
+  lock?: SnapMatchLock,
+  centerOnly?: boolean
+): SnapMatch | undefined => {
+  if (!lock) {
+    return undefined;
+  }
+  if (centerOnly && lock.type !== 'center') {
+    return undefined;
+  }
+  const neighbor = lock.neighborId
+    ? otherRects.find((item) => item.id === lock.neighborId)
+    : undefined;
+  if (lock.neighborId && !neighbor) {
+    return undefined;
+  }
+  const delta = lock.target - getEdgeValue(movingRect, lock.edge);
+  if (Math.abs(delta) > tolerance + EPSILON) {
+    return undefined;
+  }
+  const line = computeGuideLine(axis, lock.target, movingRect, neighbor?.bounds);
+  return { ...lock, delta, line };
+};
+
+const buildCandidate = (
+  axis: 'x' | 'y',
+  moving: Bounds,
+  neighbor: RectInfo,
+  edge: EdgeKey,
+  neighborEdge: EdgeKey,
+  type: 'center' | 'edge'
+): SnapMatch => {
+  const target = getEdgeValue(neighbor.bounds, neighborEdge);
+  const movingValue = getEdgeValue(moving, edge);
+  const delta = target - movingValue;
+  const line = computeGuideLine(axis, target, moving, neighbor.bounds);
+  return {
+    axis,
+    edge,
+    neighborEdge,
+    type,
+    target,
+    neighborId: neighbor.id,
+    delta,
+    line
+  };
+};
+
+const createVerticalCandidates = (moving: Bounds, neighbor: RectInfo): SnapMatch[] => {
+  return [
+    buildCandidate('x', moving, neighbor, 'left', 'left', 'edge'),
+    buildCandidate('x', moving, neighbor, 'right', 'right', 'edge'),
+    buildCandidate('x', moving, neighbor, 'left', 'right', 'edge'),
+    buildCandidate('x', moving, neighbor, 'right', 'left', 'edge'),
+    buildCandidate('x', moving, neighbor, 'centerX', 'centerX', 'center')
+  ];
+};
+
+const createHorizontalCandidates = (moving: Bounds, neighbor: RectInfo): SnapMatch[] => {
+  return [
+    buildCandidate('y', moving, neighbor, 'top', 'top', 'edge'),
+    buildCandidate('y', moving, neighbor, 'bottom', 'bottom', 'edge'),
+    buildCandidate('y', moving, neighbor, 'top', 'bottom', 'edge'),
+    buildCandidate('y', moving, neighbor, 'bottom', 'top', 'edge'),
+    buildCandidate('y', moving, neighbor, 'centerY', 'centerY', 'center')
+  ];
+};
+
+const resolveAxis = (
+  axis: 'x' | 'y',
+  movingRect: Bounds,
+  otherRects: RectInfo[],
+  tolerance: number,
+  activeLock?: SnapMatchLock,
+  centerOnly?: boolean
+): SnapMatch | undefined => {
+  const sticky = maintainLock(axis, movingRect, otherRects, tolerance, activeLock, centerOnly);
+  if (sticky) {
+    return sticky;
+  }
+
+  let best: SnapMatch | undefined;
+
+  otherRects.forEach((neighbor) => {
+    const candidates =
+      axis === 'x'
+        ? createVerticalCandidates(movingRect, neighbor)
+        : createHorizontalCandidates(movingRect, neighbor);
+
+    candidates.forEach((candidate) => {
+      if (centerOnly && candidate.type !== 'center') {
+        return;
+      }
+      const absDelta = Math.abs(candidate.delta);
+      if (absDelta > tolerance + EPSILON) {
+        return;
+      }
+
+      if (!best) {
+        best = candidate;
+        return;
+      }
+
+      const bestAbs = Math.abs(best.delta);
+      if (absDelta + EPSILON < bestAbs) {
+        best = candidate;
+        return;
+      }
+      if (Math.abs(absDelta - bestAbs) <= EPSILON) {
+        if (candidate.type === 'center' && best.type !== 'center') {
+          best = candidate;
+          return;
+        }
+        if (candidate.type === best.type && absDelta < bestAbs) {
+          best = candidate;
+        }
+      }
+    });
+  });
+
+  return best;
+};
+
+export const computeSmartGuides = ({
+  movingRect,
+  otherRects,
+  tolerance,
+  activeMatches,
+  centerOnly
+}: SmartGuideParams): SmartGuideResult => {
+  const vertical = resolveAxis(
+    'x',
+    movingRect,
+    otherRects,
+    tolerance,
+    activeMatches?.vertical,
+    centerOnly
+  );
+  const horizontal = resolveAxis(
+    'y',
+    movingRect,
+    otherRects,
+    tolerance,
+    activeMatches?.horizontal,
+    centerOnly
+  );
+
+  const guides: SnapMatch[] = [];
+  if (vertical) {
+    guides.push(vertical);
+  }
+  if (horizontal) {
+    guides.push(horizontal);
+  }
+
+  return {
+    matches: {
+      vertical: vertical ?? undefined,
+      horizontal: horizontal ?? undefined
+    },
+    guides
+  };
+};
+
+const overlapAlong = (a: Bounds, b: Bounds, axis: 'x' | 'y') =>
+  axis === 'x'
+    ? Math.min(a.maxX, b.maxX) - Math.max(a.minX, b.minX)
+    : Math.min(a.maxY, b.maxY) - Math.max(a.minY, b.minY);
+
+const alignedOnAxis = (a: Bounds, b: Bounds, axis: 'x' | 'y') => {
+  const overlap = overlapAlong(a, b, axis);
+  if (overlap >= -4) {
+    return true;
+  }
+  if (axis === 'x') {
+    const combined = widthOf(a) / 2 + widthOf(b) / 2 + 8;
+    return Math.abs(centerXOf(a) - centerXOf(b)) <= combined;
+  }
+  const combined = heightOf(a) / 2 + heightOf(b) / 2 + 8;
+  return Math.abs(centerYOf(a) - centerYOf(b)) <= combined;
+};
+
+const midpointBetween = (a: Bounds, b: Bounds, axis: 'x' | 'y') => {
+  const overlap = overlapAlong(a, b, axis === 'x' ? 'y' : 'x');
+  if (overlap > 0) {
+    const start = Math.max(
+      axis === 'x' ? a.minY : a.minX,
+      axis === 'x' ? b.minY : b.minX
+    );
+    return axis === 'x' ? start + overlap / 2 : start + overlap / 2;
+  }
+  return axis === 'x'
+    ? (centerYOf(a) + centerYOf(b)) / 2
+    : (centerXOf(a) + centerXOf(b)) / 2;
+};
+
+interface GapCandidate {
+  rect: RectInfo;
+  gap: number;
+  position: Vec2;
+  direction: 'positive' | 'negative';
+}
+
+const findHorizontalGap = (
+  movingRect: Bounds,
+  otherRects: RectInfo[],
+  direction: 'left' | 'right'
+): GapCandidate | undefined => {
+  let best: GapCandidate | undefined;
+  otherRects.forEach((candidate) => {
+    if (!alignedOnAxis(movingRect, candidate.bounds, 'y')) {
+      return;
+    }
+    if (direction === 'left') {
+      if (candidate.bounds.maxX > movingRect.minX) {
+        return;
+      }
+      const gap = movingRect.minX - candidate.bounds.maxX;
+      if (gap < 0) {
+        return;
+      }
+      if (!best || gap < best.gap) {
+        const y = midpointBetween(movingRect, candidate.bounds, 'x');
+        best = {
+          rect: candidate,
+          gap,
+          position: { x: movingRect.minX - gap / 2, y },
+          direction: 'negative'
+        };
+      }
+    } else {
+      if (candidate.bounds.minX < movingRect.maxX) {
+        return;
+      }
+      const gap = candidate.bounds.minX - movingRect.maxX;
+      if (gap < 0) {
+        return;
+      }
+      if (!best || gap < best.gap) {
+        const y = midpointBetween(movingRect, candidate.bounds, 'x');
+        best = {
+          rect: candidate,
+          gap,
+          position: { x: movingRect.maxX + gap / 2, y },
+          direction: 'positive'
+        };
+      }
+    }
+  });
+  return best;
+};
+
+const findVerticalGap = (
+  movingRect: Bounds,
+  otherRects: RectInfo[],
+  direction: 'top' | 'bottom'
+): GapCandidate | undefined => {
+  let best: GapCandidate | undefined;
+  otherRects.forEach((candidate) => {
+    if (!alignedOnAxis(movingRect, candidate.bounds, 'x')) {
+      return;
+    }
+    if (direction === 'top') {
+      if (candidate.bounds.maxY > movingRect.minY) {
+        return;
+      }
+      const gap = movingRect.minY - candidate.bounds.maxY;
+      if (gap < 0) {
+        return;
+      }
+      if (!best || gap < best.gap) {
+        const x = midpointBetween(movingRect, candidate.bounds, 'y');
+        best = {
+          rect: candidate,
+          gap,
+          position: { x, y: movingRect.minY - gap / 2 },
+          direction: 'negative'
+        };
+      }
+    } else {
+      if (candidate.bounds.minY < movingRect.maxY) {
+        return;
+      }
+      const gap = candidate.bounds.minY - movingRect.maxY;
+      if (gap < 0) {
+        return;
+      }
+      if (!best || gap < best.gap) {
+        const x = midpointBetween(movingRect, candidate.bounds, 'y');
+        best = {
+          rect: candidate,
+          gap,
+          position: { x, y: movingRect.maxY + gap / 2 },
+          direction: 'positive'
+        };
+      }
+    }
+  });
+  return best;
+};
+
+export const computeDistanceBadges = (
+  movingRect: Bounds,
+  otherRects: RectInfo[],
+  equalTolerance = 1
+): DistanceBadge[] => {
+  const badges: DistanceBadge[] = [];
+
+  const left = findHorizontalGap(movingRect, otherRects, 'left');
+  const right = findHorizontalGap(movingRect, otherRects, 'right');
+  const top = findVerticalGap(movingRect, otherRects, 'top');
+  const bottom = findVerticalGap(movingRect, otherRects, 'bottom');
+
+  if (left) {
+    badges.push({
+      id: `x-left-${left.rect.id}`,
+      axis: 'x',
+      position: left.position,
+      value: left.gap,
+      direction: left.direction
+    });
+  }
+  if (right) {
+    badges.push({
+      id: `x-right-${right.rect.id}`,
+      axis: 'x',
+      position: right.position,
+      value: right.gap,
+      direction: right.direction
+    });
+  }
+  if (top) {
+    badges.push({
+      id: `y-top-${top.rect.id}`,
+      axis: 'y',
+      position: top.position,
+      value: top.gap,
+      direction: top.direction
+    });
+  }
+  if (bottom) {
+    badges.push({
+      id: `y-bottom-${bottom.rect.id}`,
+      axis: 'y',
+      position: bottom.position,
+      value: bottom.gap,
+      direction: bottom.direction
+    });
+  }
+
+  if (left && right && Math.abs(left.gap - right.gap) <= equalTolerance) {
+    badges
+      .filter((badge) => badge.axis === 'x')
+      .forEach((badge) => {
+        badge.equal = true;
+      });
+  }
+  if (top && bottom && Math.abs(top.gap - bottom.gap) <= equalTolerance) {
+    badges
+      .filter((badge) => badge.axis === 'y')
+      .forEach((badge) => {
+        badge.equal = true;
+      });
+  }
+
+  return badges;
+};
+
+export const detectSmartSelection = (
+  rects: RectInfo[],
+  alignmentTolerance = 8,
+  spacingTolerance = 2
+): SmartSelectionResult | null => {
+  if (rects.length < 3) {
+    return null;
+  }
+
+  const centersX = rects.map((info) => info.center.x);
+  const centersY = rects.map((info) => info.center.y);
+  const rangeX = Math.max(...centersX) - Math.min(...centersX);
+  const rangeY = Math.max(...centersY) - Math.min(...centersY);
+
+  const alignedHorizontally = rangeY <= alignmentTolerance;
+  const alignedVertically = rangeX <= alignmentTolerance;
+
+  let axis: 'x' | 'y' | null = null;
+  if (alignedHorizontally && !alignedVertically) {
+    axis = 'x';
+  } else if (!alignedHorizontally && alignedVertically) {
+    axis = 'y';
+  } else if (alignedHorizontally && alignedVertically) {
+    axis = rangeX >= rangeY ? 'x' : 'y';
+  } else {
+    return null;
+  }
+
+  const sorted = [...rects].sort((a, b) =>
+    axis === 'x' ? a.bounds.minX - b.bounds.minX : a.bounds.minY - b.bounds.minY
+  );
+
+  const handles: SmartSelectionHandle[] = [];
+  const rawGaps: number[] = [];
+
+  for (let index = 0; index < sorted.length - 1; index += 1) {
+    const current = sorted[index];
+    const next = sorted[index + 1];
+    const rawGap =
+      axis === 'x'
+        ? next.bounds.minX - current.bounds.maxX
+        : next.bounds.minY - current.bounds.maxY;
+    rawGaps.push(rawGap);
+
+    const position =
+      axis === 'x'
+        ? {
+            x: current.bounds.maxX + rawGap / 2,
+            y: (current.center.y + next.center.y) / 2
+          }
+        : {
+            x: (current.center.x + next.center.x) / 2,
+            y: current.bounds.maxY + rawGap / 2
+          };
+
+    handles.push({
+      id: `${axis}-${current.id}-${next.id}`,
+      axis,
+      position,
+      beforeId: current.id,
+      affectedIds: sorted.slice(index + 1).map((item) => item.id),
+      gap: Math.max(0, rawGap),
+      rawGap
+    });
+  }
+
+  if (!handles.length) {
+    return null;
+  }
+
+  const avgGap = rawGaps.reduce((sum, value) => sum + value, 0) / rawGaps.length;
+  const isUniform = rawGaps.every(
+    (value) => Math.abs(value - avgGap) <= spacingTolerance + EPSILON
+  );
+
+  return {
+    axis,
+    handles,
+    isUniform
+  };
+};
+


### PR DESCRIPTION
## Summary
- add a dedicated snap utility module to detect alignment guides, spacing, and distances between nodes
- update the scene store and toolbar to drive a smart snap toggle and support equalized spacing commands
- enhance the canvas with smart guides, distance badges, smart selection gap handles, and supporting styles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cf06162e2c832d8cad9e75ff2592da