### PR TITLE
Improve connector editing interactions

### DIFF
--- a/src/components/ConnectorToolbar.tsx
+++ b/src/components/ConnectorToolbar.tsx
@@ -29,8 +29,7 @@ const fillOptions = [
 
 const modeOptions = [
   { value: 'orthogonal', label: 'Elbow' },
-  { value: 'straight', label: 'Straight' },
-  { value: 'curved', label: 'Curved' }
+  { value: 'straight', label: 'Straight' }
 ] as const;
 
 export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({

--- a/src/state/sceneStore.ts
+++ b/src/state/sceneStore.ts
@@ -4,6 +4,7 @@ import {
   CanvasTransform,
   ConnectorModel,
   ConnectorLabelStyle,
+  ConnectorPort,
   NodeFontWeight,
   NodeKind,
   NodeModel,
@@ -69,7 +70,11 @@ interface SceneStoreActions {
     updates: Array<{ id: string; position: Vec2; size: { width: number; height: number } }>
   ) => void;
   removeNode: (id: string) => void;
-  addConnector: (sourceId: string, targetId: string) => ConnectorModel | null;
+  addConnector: (
+    sourceId: string,
+    targetId: string,
+    options?: { sourcePort?: ConnectorPort; targetPort?: ConnectorPort }
+  ) => ConnectorModel | null;
   updateConnector: (id: string, patch: Partial<ConnectorModel>) => void;
   removeConnector: (id: string) => void;
   setSelection: (selection: SelectionState) => void;
@@ -360,7 +365,7 @@ export const useSceneStore = create<SceneStore>((set, get) => ({
         editingNodeId: current.editingNodeId === id ? null : current.editingNodeId
       };
     }),
-  addConnector: (sourceId, targetId) => {
+  addConnector: (sourceId, targetId, options) => {
     if (sourceId === targetId) {
       return null;
     }
@@ -379,6 +384,8 @@ export const useSceneStore = create<SceneStore>((set, get) => ({
       mode: 'orthogonal',
       sourceId,
       targetId,
+      sourcePort: options?.sourcePort,
+      targetPort: options?.targetPort,
       style: { ...defaultConnectorStyle },
       labelPosition: 0.5,
       labelOffset: 18,

--- a/src/styles/canvas.css
+++ b/src/styles/canvas.css
@@ -154,6 +154,7 @@
   text-align: center;
   box-shadow: 0 6px 20px rgba(2, 6, 23, 0.45);
   min-height: 20px;
+  min-width: 36px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -164,6 +165,29 @@
   user-select: text;
   cursor: text;
   outline: none;
+}
+
+.diagram-connector__label[data-placeholder]:empty::before {
+  content: attr(data-placeholder);
+  color: rgba(226, 232, 240, 0.68);
+  pointer-events: none;
+}
+
+.diagram-connector__label.is-empty:not(.is-editing) {
+  color: rgba(248, 250, 252, 0.7);
+}
+
+.diagram-connector__segment {
+  pointer-events: stroke;
+  stroke: transparent;
+  stroke-width: calc(var(--connector-width, 2) + 12);
+  stroke-linecap: round;
+  fill: none;
+  transition: stroke 0.18s ease;
+}
+
+.diagram-connector__segment.is-hovered {
+  stroke: rgba(96, 165, 250, 0.45);
 }
 
 .diagram-connector__handle {
@@ -236,6 +260,26 @@
   pointer-events: none;
   z-index: 4;
   font-family: inherit;
+}
+
+.connector-port-hint {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid rgba(148, 163, 184, 0.85);
+  background: rgba(15, 23, 42, 0.92);
+  transform: translate(-50%, -50%);
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.4);
+  transition: border-color 0.18s ease, background 0.18s ease, box-shadow 0.18s ease, opacity 0.18s ease;
+  opacity: 0.9;
+}
+
+.connector-port-hint.is-active {
+  border-color: #60a5fa;
+  background: rgba(59, 130, 246, 0.22);
+  box-shadow: 0 10px 24px rgba(59, 130, 246, 0.45);
+  opacity: 1;
 }
 
 .canvas-guides {

--- a/src/types/scene.ts
+++ b/src/types/scene.ts
@@ -37,7 +37,9 @@ export interface NodeModel {
   shadow?: boolean;
 }
 
-export type ConnectorMode = 'orthogonal' | 'straight' | 'curved';
+export type ConnectorMode = 'orthogonal' | 'straight';
+
+export type ConnectorPort = 'top' | 'right' | 'bottom' | 'left' | 'center';
 
 export type ArrowShape = 'none' | 'triangle' | 'diamond' | 'circle';
 export type ArrowFill = 'filled' | 'outlined';
@@ -69,6 +71,8 @@ export interface ConnectorModel {
   mode: ConnectorMode;
   sourceId: string;
   targetId: string;
+  sourcePort?: ConnectorPort;
+  targetPort?: ConnectorPort;
   points?: Vec2[];
   label?: string;
   labelPosition?: number;


### PR DESCRIPTION
## Summary
- keep connector label editing focused, including IME/paste handling and label hover affordances
- support Alt-drag splitting for orthogonal connectors with cleaned up segment dragging updates
- adjust orthogonal tidy logic to preserve manual elbows while collapsing near-straight segments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d0189855c0832dac23d6d2a63ad8ea