### PR TITLE
Add connector invariants tests and path normalization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 .dist
 build
+build-tests
 .DS_Store
 .env.local
 .env*

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "test": "node -e \"fs.rmSync('build-tests',{recursive:true,force:true});\" && tsc --project tsconfig.tests.json && node scripts/fix-esm-extensions.mjs && node --test build-tests/utils/__tests__/connector.test.js",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/scripts/fix-esm-extensions.mjs
+++ b/scripts/fix-esm-extensions.mjs
@@ -1,0 +1,59 @@
+import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { join, extname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = new URL('../build-tests', import.meta.url);
+const ROOT_PATH = fileURLToPath(ROOT);
+
+const isRelativeSpecifier = (value) => value.startsWith('./') || value.startsWith('../');
+
+const normalizeSpecifier = (specifier) => {
+  if (!isRelativeSpecifier(specifier)) {
+    return specifier;
+  }
+  if (specifier.endsWith('.js') || specifier.endsWith('.json') || specifier.endsWith('.mjs')) {
+    return specifier;
+  }
+  if (specifier.endsWith('.ts')) {
+    return `${specifier.slice(0, -3)}.js`;
+  }
+  const trailing = specifier.split('/').pop() ?? '';
+  if (!extname(trailing)) {
+    return `${specifier}.js`;
+  }
+  return specifier;
+};
+
+const RELATIVE_FROM_PATTERN = /((?:import|export)[^'";]*?from\s+['"])([^'"\s]+)(['"])/g;
+const RELATIVE_DYNAMIC_PATTERN = /(import\(\s*['"])([^'"\s]+)(['"]\s*\))/g;
+
+const fixFile = (filePath) => {
+  const original = readFileSync(filePath, 'utf8');
+  let updated = original.replace(RELATIVE_FROM_PATTERN, (match, start, specifier, end) => {
+    const next = normalizeSpecifier(specifier);
+    return `${start}${next}${end}`;
+  });
+  updated = updated.replace(RELATIVE_DYNAMIC_PATTERN, (match, start, specifier, end) => {
+    const next = normalizeSpecifier(specifier);
+    return `${start}${next}${end}`;
+  });
+
+  if (updated !== original) {
+    writeFileSync(filePath, updated, 'utf8');
+  }
+};
+
+const walk = (directory) => {
+  const entries = readdirSync(directory);
+  for (const entry of entries) {
+    const fullPath = join(directory, entry);
+    const stats = statSync(fullPath);
+    if (stats.isDirectory()) {
+      walk(fullPath);
+    } else if (stats.isFile() && fullPath.endsWith('.js')) {
+      fixFile(fullPath);
+    }
+  }
+};
+
+walk(ROOT_PATH);

--- a/src/components/ConnectorToolbar.tsx
+++ b/src/components/ConnectorToolbar.tsx
@@ -34,7 +34,7 @@ const fillOptions = [
 ] as const;
 
 const modeOptions = [
-  { value: 'orthogonal', label: 'Elbow' },
+  { value: 'elbow', label: 'Elbow' },
   { value: 'straight', label: 'Straight' }
 ] as const;
 
@@ -304,7 +304,7 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
             ))}
           </select>
         </label>
-        {connector.mode === 'orthogonal' && (
+        {connector.mode === 'elbow' && (
           <label className="connector-toolbar__field">
             <span>Corner</span>
             <input

--- a/src/components/DiagramConnector.tsx
+++ b/src/components/DiagramConnector.tsx
@@ -214,33 +214,15 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
     }
   }, [labelEditing, draft]);
 
-  const geometry = useMemo(() => {
-    if (!source || !target) {
-      return null;
-    }
-    return getConnectorPath(connector, source, target);
-  }, [connector, source, target]);
+  const geometry = useMemo(() => getConnectorPath(connector, source, target), [connector, source, target]);
 
-  const cornerRadius = connector.mode === 'orthogonal' ? connector.style.cornerRadius ?? 12 : 0;
+  const cornerRadius = connector.mode === 'elbow' ? connector.style.cornerRadius ?? 12 : 0;
 
-  const pathData = useMemo(() => {
-    if (!geometry) {
-      return '';
-    }
-    return buildRoundedPath(geometry.points, cornerRadius);
-  }, [geometry, cornerRadius]);
+  const pathData = useMemo(() => buildRoundedPath(geometry.points, cornerRadius), [geometry, cornerRadius]);
 
-  const hitPathData = useMemo(() => {
-    if (!geometry) {
-      return '';
-    }
-    return buildRoundedPath(geometry.points, 0);
-  }, [geometry]);
+  const hitPathData = useMemo(() => buildRoundedPath(geometry.points, 0), [geometry]);
 
   const segments = useMemo(() => {
-    if (!geometry) {
-      return [] as Array<{ start: Vec2; end: Vec2; axis: 'horizontal' | 'vertical'; index: number }>;
-    }
     const list: Array<{ start: Vec2; end: Vec2; axis: 'horizontal' | 'vertical'; index: number }> = [];
     for (let index = 0; index < geometry.points.length - 1; index += 1) {
       const start = geometry.points[index];
@@ -257,25 +239,12 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
     }
   }, [selected]);
 
-  const midpoint = useMemo(() => {
-    if (!geometry) {
-      return { x: 0, y: 0 };
-    }
-    return getPolylineMidpoint(geometry.points);
-  }, [geometry]);
+  const midpoint = useMemo(() => getPolylineMidpoint(geometry.points), [geometry]);
 
   const labelPosition = connector.labelPosition ?? DEFAULT_LABEL_POSITION;
   const labelOffset = connector.labelOffset ?? DEFAULT_LABEL_OFFSET;
 
   const labelPlacement = useMemo(() => {
-    if (!geometry) {
-      return {
-        anchor: midpoint,
-        center: midpoint,
-        normal: { x: 0, y: -1 },
-        segmentIndex: 0
-      };
-    }
     const { point, segmentIndex } = getPointAtRatio(geometry.points, labelPosition);
     const normal = getNormalAtRatio(geometry.points, segmentIndex);
     const center = {
@@ -368,10 +337,6 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
       )}
     </marker>
   );
-
-  if (!geometry) {
-    return null;
-  }
 
   const handleLabelInput = (event: React.FormEvent<HTMLDivElement>) => {
     setDraft(event.currentTarget.textContent ?? '');
@@ -556,7 +521,7 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
           />
         </>
       )}
-      {selected && connector.mode === 'orthogonal' &&
+      {selected && connector.mode === 'elbow' &&
         geometry.points.slice(1, geometry.points.length - 1).map((point, index) => {
           const previous = geometry.points[index];
           const next = geometry.points[index + 2];

--- a/src/types/scene.ts
+++ b/src/types/scene.ts
@@ -37,11 +37,28 @@ export interface NodeModel {
   shadow?: boolean;
 }
 
-export type ConnectorMode = 'orthogonal' | 'straight';
+export type ConnectorMode = 'elbow' | 'straight';
 
 export type CardinalConnectorPort = 'top' | 'right' | 'bottom' | 'left';
 
-export type ConnectorPort = CardinalConnectorPort | 'center';
+export interface AttachedConnectorEndpoint {
+  nodeId: string;
+  port: CardinalConnectorPort;
+}
+
+export interface FloatingConnectorEndpoint {
+  position: Vec2;
+}
+
+export type ConnectorEndpoint = AttachedConnectorEndpoint | FloatingConnectorEndpoint;
+
+export const isAttachedConnectorEndpoint = (
+  endpoint: ConnectorEndpoint
+): endpoint is AttachedConnectorEndpoint => 'nodeId' in endpoint;
+
+export const isFloatingConnectorEndpoint = (
+  endpoint: ConnectorEndpoint
+): endpoint is FloatingConnectorEndpoint => 'position' in endpoint;
 
 export type ArrowShape = 'none' | 'triangle' | 'diamond' | 'circle' | 'arrow' | 'line-arrow';
 export type ArrowFill = 'filled' | 'outlined';
@@ -71,10 +88,8 @@ export interface ConnectorStyle {
 export interface ConnectorModel {
   id: string;
   mode: ConnectorMode;
-  sourceId: string;
-  targetId: string;
-  sourcePort?: ConnectorPort;
-  targetPort?: ConnectorPort;
+  source: ConnectorEndpoint;
+  target: ConnectorEndpoint;
   points?: Vec2[];
   label?: string;
   labelPosition?: number;

--- a/src/types/test-globals.d.ts
+++ b/src/types/test-globals.d.ts
@@ -1,0 +1,28 @@
+declare module 'node:test' {
+  type TestFn = (t: unknown) => void | Promise<void>;
+  const test: {
+    (name: string, fn: TestFn): void;
+    (fn: TestFn): void;
+  };
+  export default test;
+}
+
+declare module 'node:assert/strict' {
+  const assert: {
+    (value: unknown, message?: string | Error): asserts value;
+    ok(value: unknown, message?: string | Error): asserts value;
+    strictEqual<T>(actual: T, expected: T, message?: string | Error): void;
+    deepStrictEqual(actual: unknown, expected: unknown, message?: string | Error): void;
+    throws(fn: (...args: unknown[]) => unknown, expected?: unknown, message?: string | Error): void;
+    fail(message?: string | Error): never;
+  } & Record<string, unknown>;
+  export default assert;
+}
+
+declare interface ImportMetaEnv {
+  readonly DEV?: boolean;
+}
+
+declare interface ImportMeta {
+  readonly env?: ImportMetaEnv;
+}

--- a/src/utils/__tests__/connector.test.ts
+++ b/src/utils/__tests__/connector.test.ts
@@ -1,0 +1,232 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  CARDINAL_PORTS,
+  cloneConnectorEndpoint,
+  getConnectorPath,
+  getConnectorPortPositions,
+  isCardinalConnectorPortValue,
+  tidyOrthogonalWaypoints
+} from '../connector';
+import type {
+  CardinalConnectorPort,
+  ConnectorModel,
+  NodeModel,
+  Vec2
+} from '../../types/scene';
+
+type Mutable<T> = {
+  -readonly [K in keyof T]: T[K];
+};
+
+const createNode = (
+  id: string,
+  position: Vec2,
+  size: { width: number; height: number } = { width: 160, height: 120 }
+): NodeModel => ({
+  id,
+  shape: 'rectangle',
+  position: { ...position },
+  size: { ...size },
+  text: '',
+  textAlign: 'center',
+  fontSize: 16,
+  fontWeight: 600,
+  fill: '#ffffff',
+  fillOpacity: 1,
+  stroke: { color: '#0f172a', width: 1 },
+  shadow: false
+});
+
+const defaultConnectorStyle: Mutable<ConnectorModel['style']> = {
+  stroke: '#111827',
+  strokeWidth: 2,
+  dashed: false,
+  startArrow: { shape: 'none', fill: 'filled' },
+  endArrow: { shape: 'arrow', fill: 'filled' },
+  arrowSize: 1,
+  cornerRadius: 12
+};
+
+const createConnector = (
+  mode: ConnectorModel['mode'],
+  sourcePort: CardinalConnectorPort,
+  targetPort: CardinalConnectorPort
+): ConnectorModel => ({
+  id: 'connector',
+  mode,
+  source: { nodeId: 'source', port: sourcePort },
+  target: { nodeId: 'target', port: targetPort },
+  style: { ...defaultConnectorStyle },
+  labelPosition: 0.5,
+  labelOffset: 18
+});
+
+const createRng = (seed: number) => () => {
+  seed = (seed * 1664525 + 1013904223) >>> 0;
+  return seed / 0x100000000;
+};
+
+test('cardinal connector ports recognise the supported values', () => {
+  for (const port of CARDINAL_PORTS) {
+    assert.ok(isCardinalConnectorPortValue(port), `Expected ${port} to be recognised.`);
+  }
+  assert.ok(!isCardinalConnectorPortValue('center'));
+  assert.ok(!isCardinalConnectorPortValue('auto'));
+});
+
+test('connector port positions align to side midpoints', () => {
+  const node = createNode('node', { x: 40, y: 100 }, { width: 120, height: 80 });
+  const ports = getConnectorPortPositions(node);
+  assert.deepStrictEqual(ports.top, { x: 100, y: 100 });
+  assert.deepStrictEqual(ports.right, { x: 160, y: 140 });
+  assert.deepStrictEqual(ports.bottom, { x: 100, y: 180 });
+  assert.deepStrictEqual(ports.left, { x: 40, y: 140 });
+});
+
+test('cloneConnectorEndpoint rejects non-cardinal attachments', () => {
+  const attached = { nodeId: 'node', port: 'center' as unknown as CardinalConnectorPort };
+  assert.throws(() => cloneConnectorEndpoint(attached), /cardinal/i);
+});
+
+test('elbow connectors remain orthogonal and perpendicular at ports', () => {
+  const rng = createRng(1337);
+
+  for (let iteration = 0; iteration < 16; iteration += 1) {
+    const source = createNode(
+      'source',
+      {
+        x: Math.round((rng() - 0.5) * 800),
+        y: Math.round((rng() - 0.5) * 600)
+      },
+      {
+        width: 120 + Math.round(rng() * 120),
+        height: 90 + Math.round(rng() * 90)
+      }
+    );
+    const target = createNode(
+      'target',
+      {
+        x: Math.round((rng() - 0.5) * 800) + 200,
+        y: Math.round((rng() - 0.5) * 600) + 200
+      },
+      {
+        width: 120 + Math.round(rng() * 120),
+        height: 90 + Math.round(rng() * 90)
+      }
+    );
+
+    for (const startPort of CARDINAL_PORTS) {
+      for (const endPort of CARDINAL_PORTS) {
+        const connector = createConnector('elbow', startPort, endPort);
+        let path: ReturnType<typeof getConnectorPath> | null = null;
+        try {
+          path = getConnectorPath(connector, source, target);
+        } catch (error) {
+          assert.fail(
+            `Routing failed for ${startPort}→${endPort} (iteration ${iteration}): ${(error as Error).message}`
+          );
+        }
+        if (!path) {
+          continue;
+        }
+
+        assert.ok(path.points.length >= 2);
+
+        for (let index = 0; index < path.points.length - 1; index += 1) {
+          const a = path.points[index];
+          const b = path.points[index + 1];
+          const dx = Math.abs(b.x - a.x);
+          const dy = Math.abs(b.y - a.y);
+          const orthogonal = dx < 1e-6 || dy < 1e-6;
+          assert.ok(orthogonal, 'Segments must be orthogonal.');
+        }
+
+        const first = path.points[0];
+        const second = path.points[1];
+        if (startPort === 'top' || startPort === 'bottom') {
+          assert.ok(Math.abs(second.x - first.x) < 1e-6);
+          const delta = second.y - first.y;
+          if (startPort === 'top') {
+            assert.ok(delta < 0);
+          } else {
+            assert.ok(delta > 0);
+          }
+        } else {
+          assert.ok(Math.abs(second.y - first.y) < 1e-6);
+          const delta = second.x - first.x;
+          if (startPort === 'left') {
+            assert.ok(delta < 0);
+          } else {
+            assert.ok(delta > 0);
+          }
+        }
+
+        const penultimate = path.points[path.points.length - 2];
+        const last = path.points[path.points.length - 1];
+        if (endPort === 'top' || endPort === 'bottom') {
+          assert.ok(Math.abs(last.x - penultimate.x) < 1e-6);
+          const delta = last.y - penultimate.y;
+          if (endPort === 'top') {
+            assert.ok(delta > 0);
+          } else {
+            assert.ok(delta < 0);
+          }
+        } else {
+          assert.ok(Math.abs(last.y - penultimate.y) < 1e-6);
+          const delta = last.x - penultimate.x;
+          if (endPort === 'left') {
+            assert.ok(delta > 0);
+          } else {
+            assert.ok(delta < 0);
+          }
+        }
+      }
+    }
+  }
+});
+
+test('straight connectors produce a single segment between ports', () => {
+  const source = createNode('source', { x: 0, y: 0 });
+  const target = createNode('target', { x: 320, y: 200 });
+  const connector = createConnector('straight', 'right', 'left');
+  const path = getConnectorPath(connector, source, target);
+  assert.deepStrictEqual(path.waypoints, []);
+  assert.strictEqual(path.points.length, 2);
+  assert.deepStrictEqual(path.points[0], getConnectorPortPositions(source).right);
+  assert.deepStrictEqual(path.points[1], getConnectorPortPositions(target).left);
+});
+
+test('tidyOrthogonalWaypoints collapses redundant points', () => {
+  const start = { x: 0, y: 0 };
+  const end = { x: 200, y: 160 };
+  const base: Vec2[] = [
+    { x: 0, y: 40 },
+    { x: 0.4, y: 40 },
+    { x: 0.4, y: 120 },
+    { x: 0.4000001, y: 120.0000001 },
+    { x: 180, y: 120 },
+    { x: 180, y: 150 }
+  ];
+
+  const tidy = tidyOrthogonalWaypoints(start, base, end);
+  assert.ok(tidy.length < base.length);
+
+  const points = [start, ...tidy, end];
+  for (let index = 0; index < points.length - 1; index += 1) {
+    const current = points[index];
+    const next = points[index + 1];
+    const dx = Math.abs(next.x - current.x);
+    const dy = Math.abs(next.y - current.y);
+    const orthogonal = dx < 1e-6 || dy < 1e-6;
+    assert.ok(orthogonal, 'Segments must remain orthogonal.');
+  }
+
+  for (let index = 1; index < tidy.length; index += 1) {
+    const prev = tidy[index - 1];
+    const current = tidy[index];
+    const dx = Math.abs(prev.x - current.x);
+    const dy = Math.abs(prev.y - current.y);
+    assert.ok(dx > 1e-6 || dy > 1e-6, 'Consecutive points must not collapse to duplicates.');
+  }
+});

--- a/src/utils/scene.ts
+++ b/src/utils/scene.ts
@@ -6,6 +6,7 @@ import {
   SceneContent,
   Vec2
 } from '../types/scene';
+import { cloneConnectorEndpoint } from './connector';
 
 export const GRID_SIZE = 32;
 
@@ -90,6 +91,8 @@ export const cloneScene = (scene: SceneContent): SceneContent => ({
   })),
   connectors: scene.connectors.map((connector) => ({
     ...connector,
+    source: cloneConnectorEndpoint(connector.source),
+    target: cloneConnectorEndpoint(connector.target),
     points: connector.points?.map((point) => ({ ...point }))
   }))
 });

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./build-tests",
+    "declaration": false,
+    "emitDeclarationOnly": false,
+    "sourceMap": false,
+    "module": "ES2020",
+    "target": "ES2020",
+    "moduleResolution": "Node"
+  },
+  "include": [
+    "src/types/**/*.ts",
+    "src/types/**/*.d.ts",
+    "src/utils/**/*.ts"
+  ],
+  "exclude": []
+}


### PR DESCRIPTION
## Summary
- enforce cardinal port assertions and orthogonal path normalization in the connector utilities
- add Node-based connector routing tests with minimal Node typings
- wire up a standalone test build configuration and helper script to normalize compiled ESM imports

## Testing
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d06e0b5398832d8ae7760ca6815f69