### PR TITLE
Improve connector endpoint affordance and preview geometry

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -18,8 +18,7 @@ import {
   NodeModel,
   Tool,
   Vec2,
-  isAttachedConnectorEndpoint,
-  isFloatingConnectorEndpoint
+  isAttachedConnectorEndpoint
 } from '../types/scene';
 import {
   GRID_SIZE,
@@ -37,6 +36,7 @@ import {
   findClosestPointOnPolyline,
   CARDINAL_PORTS,
   cloneConnectorEndpoint,
+  buildRoundedConnectorPath,
   getConnectorPath,
   getConnectorPortAnchor,
   getConnectorPortPositions,
@@ -99,6 +99,16 @@ const PORT_PRIORITY: Record<CardinalConnectorPort, number> = {
   right: 1,
   bottom: 2,
   left: 3
+};
+
+const PENDING_CONNECTOR_STYLE: ConnectorModel['style'] = {
+  stroke: '#e5e7eb',
+  strokeWidth: 2,
+  dashed: false,
+  startArrow: { shape: 'none', fill: 'filled' },
+  endArrow: { shape: 'arrow', fill: 'filled' },
+  arrowSize: 1,
+  cornerRadius: 12
 };
 
 const pointsRoughlyEqual = (a: Vec2, b: Vec2) =>
@@ -2347,40 +2357,73 @@ const CanvasComponent = (
     } as React.CSSProperties;
   }, [transform, gridVisible]);
 
-  const pendingLine = useMemo(() => {
+  const pendingPreview = useMemo(() => {
     if (!pendingConnection) {
       return null;
     }
+
+    const createPreview = (model: ConnectorModel) => {
+      const sourceNode = resolveEndpointNode(model.source);
+      const targetNode = resolveEndpointNode(model.target);
+      const geometry = getConnectorPath(model, sourceNode, targetNode);
+      const radius = model.mode === 'elbow' ? model.style.cornerRadius ?? 12 : 0;
+      const path = buildRoundedConnectorPath(geometry.points, radius);
+      if (!path) {
+        return null;
+      }
+      return {
+        path,
+        strokeWidth: model.style.strokeWidth ?? 2
+      };
+    };
 
     if (pendingConnection.type === 'reconnect') {
       const connector = connectors.find((item) => item.id === pendingConnection.connectorId);
       if (!connector) {
         return null;
       }
-      const otherEndpoint = pendingConnection.endpoint === 'source' ? connector.target : connector.source;
-      let anchor: Vec2;
-      if (isAttachedConnectorEndpoint(otherEndpoint)) {
-        const node = resolveEndpointNode(otherEndpoint);
-        anchor = node ? getConnectorPortAnchor(node, otherEndpoint.port) : pendingConnection.worldPoint;
-      } else if (isFloatingConnectorEndpoint(otherEndpoint)) {
-        anchor = otherEndpoint.position;
-      } else {
-        anchor = pendingConnection.worldPoint;
-      }
 
-      if (pendingConnection.endpoint === 'source') {
-        return { start: pendingConnection.worldPoint, end: anchor };
-      }
-      return { start: anchor, end: pendingConnection.worldPoint };
+      const movingEndpoint: ConnectorEndpoint =
+        !pendingConnection.bypassSnap && pendingConnection.snapPort
+          ? { nodeId: pendingConnection.snapPort.nodeId, port: pendingConnection.snapPort.port }
+          : { position: { ...pendingConnection.worldPoint } };
+      const fixedEndpoint = cloneConnectorEndpoint(pendingConnection.fixed);
+
+      const previewConnector: ConnectorModel =
+        pendingConnection.endpoint === 'source'
+          ? {
+              ...connector,
+              source: movingEndpoint,
+              target: fixedEndpoint,
+              points: [],
+              style: { ...connector.style }
+            }
+          : {
+              ...connector,
+              source: fixedEndpoint,
+              target: movingEndpoint,
+              points: [],
+              style: { ...connector.style }
+            };
+
+      return createPreview(previewConnector);
     }
 
-    const sourceEndpoint = pendingConnection.source;
-    let start: Vec2 = pendingConnection.worldPoint;
-    if (isAttachedConnectorEndpoint(sourceEndpoint)) {
-      const node = resolveEndpointNode(sourceEndpoint);
-      start = node ? getConnectorPortAnchor(node, sourceEndpoint.port) : start;
-    }
-    return { start, end: pendingConnection.worldPoint };
+    const targetEndpoint: ConnectorEndpoint =
+      !pendingConnection.bypassSnap && pendingConnection.snapPort
+        ? { nodeId: pendingConnection.snapPort.nodeId, port: pendingConnection.snapPort.port }
+        : { position: { ...pendingConnection.worldPoint } };
+
+    const previewConnector: ConnectorModel = {
+      id: 'pending',
+      mode: 'elbow',
+      source: cloneConnectorEndpoint(pendingConnection.source),
+      target: targetEndpoint,
+      points: [],
+      style: { ...PENDING_CONNECTOR_STYLE }
+    };
+
+    return createPreview(previewConnector);
   }, [pendingConnection, connectors, resolveEndpointNode]);
 
   return (
@@ -2477,16 +2520,14 @@ const CanvasComponent = (
               onDoubleClick={(event) => handleNodeDoubleClick(event, node)}
             />
           ))}
+          {pendingPreview && (
+            <path
+              className="connector-pending"
+              d={pendingPreview.path}
+              strokeWidth={pendingPreview.strokeWidth}
+            />
+          )}
         </g>
-      {pendingLine && (
-        <line
-          className="connector-pending"
-          x1={pendingLine.start.x * transform.scale + transform.x}
-          y1={pendingLine.start.y * transform.scale + transform.y}
-          x2={pendingLine.end.x * transform.scale + transform.x}
-          y2={pendingLine.end.y * transform.scale + transform.y}
-        />
-      )}
       </svg>
       <div className="canvas-overlays" aria-hidden>
         <svg className="canvas-guides" aria-hidden>

--- a/src/styles/canvas.css
+++ b/src/styles/canvas.css
@@ -213,11 +213,55 @@
   stroke-width: 3;
 }
 
+.diagram-connector__endpoint-group {
+  pointer-events: none;
+  transition: color 0.18s ease;
+}
+
+.diagram-connector__endpoint-group.is-hovered {
+  color: rgba(59, 130, 246, 0.95);
+}
+
+.diagram-connector__endpoint-visual {
+  pointer-events: none;
+  fill: currentColor;
+  stroke: rgba(15, 23, 42, 0.85);
+  stroke-width: 1.4;
+  opacity: 0.88;
+  filter: drop-shadow(0 2px 6px rgba(15, 23, 42, 0.45));
+  transform-box: fill-box;
+  transform-origin: center;
+  transition: transform 0.18s ease, opacity 0.18s ease, stroke 0.18s ease, fill 0.18s ease;
+}
+
+.diagram-connector__endpoint-visual.is-hovered {
+  transform: scale(1.12);
+  opacity: 1;
+  stroke: rgba(15, 23, 42, 0.6);
+}
+
 .diagram-connector__endpoint-hit {
   pointer-events: all;
   fill: transparent;
   stroke: transparent;
   cursor: grab;
+  transform-box: fill-box;
+  transform-origin: center;
+  transition: transform 0.18s ease, fill 0.18s ease, stroke 0.18s ease;
+}
+
+.diagram-connector__endpoint-hit.is-hovered {
+  fill: rgba(59, 130, 246, 0.18);
+  stroke: rgba(59, 130, 246, 0.7);
+  stroke-width: 1.5;
+  transform: scale(1.12);
+}
+
+.diagram-connector__endpoint-hit.is-hovered:active {
+  cursor: grabbing;
+  fill: rgba(59, 130, 246, 0.28);
+  stroke: rgba(59, 130, 246, 0.8);
+  transform: scale(1.05);
 }
 
 .diagram-connector__label-leader {
@@ -382,6 +426,9 @@
   stroke: rgba(96, 165, 250, 0.65);
   stroke-width: 2;
   stroke-dasharray: 6 6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  fill: none;
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary
- highlight connector endpoints on hover with dedicated visuals to make grabbing easier
- reuse a shared rounded path builder and draw pending connector previews using full orthogonal paths
- render pending connections as styled paths inside the canvas so connector reattachments look intuitive

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d0b0bbd698832d92341decd7564dd0