### PR TITLE
Improve connector editing UX

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -486,7 +486,7 @@ const CanvasComponent = (
     }
     const sourceNode = resolveEndpointNode(selectedConnector.source);
     const targetNode = resolveEndpointNode(selectedConnector.target);
-    const geometry = getConnectorPath(selectedConnector, sourceNode, targetNode);
+    const geometry = getConnectorPath(selectedConnector, sourceNode, targetNode, nodes);
     if (!geometry.points.length) {
       return null;
     }
@@ -501,7 +501,7 @@ const CanvasComponent = (
     }
     const sourceNode = resolveEndpointNode(selectedConnector.source);
     const targetNode = resolveEndpointNode(selectedConnector.target);
-    const geometry = getConnectorPath(selectedConnector, sourceNode, targetNode);
+    const geometry = getConnectorPath(selectedConnector, sourceNode, targetNode, nodes);
     if (!geometry.points.length) {
       return null;
     }
@@ -732,7 +732,7 @@ const CanvasComponent = (
     (connector: ConnectorModel) => {
       const sourceNode = resolveEndpointNode(connector.source);
       const targetNode = resolveEndpointNode(connector.target);
-      const geometry = getConnectorPath(connector, sourceNode, targetNode);
+      const geometry = getConnectorPath(connector, sourceNode, targetNode, nodes);
       if (connector.mode === 'elbow') {
         const waypoints = tidyOrthogonalWaypoints(geometry.start, geometry.waypoints, geometry.end);
         updateConnector(connector.id, { points: waypoints });
@@ -1104,7 +1104,7 @@ const CanvasComponent = (
       }
       const sourceNode = resolveEndpointNode(connector.source);
       const targetNode = resolveEndpointNode(connector.target);
-      const geometry = getConnectorPath(connector, sourceNode, targetNode);
+      const geometry = getConnectorPath(connector, sourceNode, targetNode, nodes);
       if (geometry.points.length < 2) {
         return;
       }
@@ -1776,7 +1776,7 @@ const CanvasComponent = (
 
     const sourceNode = resolveEndpointNode(connector.source);
     const targetNode = resolveEndpointNode(connector.target);
-    const geometry = getConnectorPath(connector, sourceNode, targetNode);
+    const geometry = getConnectorPath(connector, sourceNode, targetNode, nodes);
     if (geometry.points.length < 2) {
       return;
     }
@@ -1878,7 +1878,7 @@ const CanvasComponent = (
       return;
     }
 
-    const geometry = getConnectorPath(connector, sourceNode, targetNode);
+    const geometry = getConnectorPath(connector, sourceNode, targetNode, nodes);
     if (!geometry.points[pointIndex + 1]) {
       return;
     }
@@ -2365,7 +2365,7 @@ const CanvasComponent = (
     const createPreview = (model: ConnectorModel) => {
       const sourceNode = resolveEndpointNode(model.source);
       const targetNode = resolveEndpointNode(model.target);
-      const geometry = getConnectorPath(model, sourceNode, targetNode);
+      const geometry = getConnectorPath(model, sourceNode, targetNode, nodes);
       const radius = model.mode === 'elbow' ? model.style.cornerRadius ?? 12 : 0;
       const path = buildRoundedConnectorPath(geometry.points, radius);
       if (!path) {
@@ -2488,6 +2488,7 @@ const CanvasComponent = (
               connector={connector}
               source={resolveEndpointNode(connector.source)}
               target={resolveEndpointNode(connector.target)}
+              nodes={nodes}
               selected={selectedConnectorIds.includes(connector.id)}
               labelEditing={editingConnectorId === connector.id}
               commitSignal={connectorCommitSignal}

--- a/src/components/ConnectorTextToolbar.tsx
+++ b/src/components/ConnectorTextToolbar.tsx
@@ -3,6 +3,7 @@ import { ConnectorModel } from '../types/scene';
 import { FloatingMenuChrome } from './FloatingMenuChrome';
 import { useFloatingMenuDrag } from '../hooks/useFloatingMenuDrag';
 import { computeFloatingMenuPlacement } from '../utils/floatingMenu';
+import { useFrozenFloatingPlacement } from '../hooks/useFrozenFloatingPlacement';
 import '../styles/connector-toolbar.css';
 
 interface ConnectorTextToolbarProps {
@@ -52,18 +53,18 @@ export const ConnectorTextToolbar: React.FC<ConnectorTextToolbarProps> = ({
     isVisible: isVisible && Boolean(anchor)
   });
 
-  const anchoredPlacement = useMemo(() => {
-    if (!anchor || menuState.isFree) {
-      return null;
-    }
-    return computeFloatingMenuPlacement(
-      { x: anchor.x, y: anchor.y, width: 0, height: 0 },
-      menuSize ?? { width: 0, height: 0 },
-      viewportSize,
-      pointerPosition,
-      { gap: TOOLBAR_OFFSET }
-    );
-  }, [anchor, menuState.isFree, menuSize, viewportSize, pointerPosition]);
+  const placementOptions = useMemo(() => ({ gap: TOOLBAR_OFFSET }), []);
+
+  const { placement: anchoredPlacement, orientation } = useFrozenFloatingPlacement({
+    anchor: anchor ? { x: anchor.x, y: anchor.y, width: 0, height: 0 } : null,
+    menuState,
+    menuSize,
+    viewportSize,
+    pointerPosition,
+    options: placementOptions,
+    isVisible: isVisible && Boolean(anchor),
+    identity: connector.id
+  });
 
   const style = useMemo(() => {
     if (!anchor) {
@@ -83,7 +84,7 @@ export const ConnectorTextToolbar: React.FC<ConnectorTextToolbarProps> = ({
         menuSize ?? { width: 0, height: 0 },
         viewportSize,
         pointerPosition,
-        { gap: TOOLBAR_OFFSET }
+        placementOptions
       );
 
     return {
@@ -91,9 +92,16 @@ export const ConnectorTextToolbar: React.FC<ConnectorTextToolbarProps> = ({
       top: 0,
       transform: `translate3d(${placementResult.position.x}px, ${placementResult.position.y}px, 0)`
     } as React.CSSProperties;
-  }, [anchor, anchoredPlacement, menuState.isFree, menuState.position, menuSize, viewportSize, pointerPosition]);
-
-  const orientation = anchoredPlacement?.orientation ?? 'top';
+  }, [
+    anchor,
+    anchoredPlacement,
+    menuState.isFree,
+    menuState.position,
+    menuSize,
+    viewportSize,
+    pointerPosition,
+    placementOptions
+  ]);
 
   if (!isVisible || !anchor) {
     return null;

--- a/src/components/DiagramConnector.tsx
+++ b/src/components/DiagramConnector.tsx
@@ -12,6 +12,7 @@ interface DiagramConnectorProps {
   connector: ConnectorModel;
   source?: NodeModel;
   target?: NodeModel;
+  nodes: NodeModel[];
   selected: boolean;
   labelEditing: boolean;
   commitSignal: number;
@@ -117,6 +118,7 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
   connector,
   source,
   target,
+  nodes,
   selected,
   labelEditing,
   commitSignal,
@@ -175,7 +177,10 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
     }
   }, [labelEditing, draft]);
 
-  const geometry = useMemo(() => getConnectorPath(connector, source, target), [connector, source, target]);
+  const geometry = useMemo(
+    () => getConnectorPath(connector, source, target, nodes),
+    [connector, source, target, nodes]
+  );
 
   const cornerRadius = connector.mode === 'elbow' ? connector.style.cornerRadius ?? 12 : 0;
 
@@ -482,13 +487,13 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
               className={`diagram-connector__endpoint-visual${startHovered ? ' is-hovered' : ''}`}
               cx={geometry.start.x}
               cy={geometry.start.y}
-              r={4.5}
+              r={5.5}
             />
             <circle
               className={`diagram-connector__endpoint-hit${startHovered ? ' is-hovered' : ''}`}
               cx={geometry.start.x}
               cy={geometry.start.y}
-              r={12}
+              r={16}
               onPointerEnter={() => setHoveredEndpoint('start')}
               onPointerLeave={() =>
                 setHoveredEndpoint((value) => (value === 'start' ? null : value))
@@ -507,13 +512,13 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
               className={`diagram-connector__endpoint-visual${endHovered ? ' is-hovered' : ''}`}
               cx={geometry.end.x}
               cy={geometry.end.y}
-              r={4.5}
+              r={5.5}
             />
             <circle
               className={`diagram-connector__endpoint-hit${endHovered ? ' is-hovered' : ''}`}
               cx={geometry.end.x}
               cy={geometry.end.y}
-              r={12}
+              r={16}
               onPointerEnter={() => setHoveredEndpoint('end')}
               onPointerLeave={() => setHoveredEndpoint((value) => (value === 'end' ? null : value))}
               onPointerDown={(event) => {

--- a/src/hooks/useFrozenFloatingPlacement.ts
+++ b/src/hooks/useFrozenFloatingPlacement.ts
@@ -1,0 +1,141 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { FloatingMenuPlacement } from '../state/menuStore';
+import {
+  FloatingMenuAnchorRect,
+  FloatingMenuPlacementOptions,
+  FloatingMenuPlacementResult,
+  FloatingMenuOrientation,
+  computeFloatingMenuPlacement
+} from '../utils/floatingMenu';
+
+const ANCHOR_EPSILON = 0.5;
+
+const cloneAnchor = (anchor: FloatingMenuAnchorRect | null): FloatingMenuAnchorRect | null => {
+  if (!anchor) {
+    return null;
+  }
+  return {
+    x: anchor.x,
+    y: anchor.y,
+    width: anchor.width,
+    height: anchor.height
+  };
+};
+
+const anchorsDiffer = (a: FloatingMenuAnchorRect | null, b: FloatingMenuAnchorRect | null): boolean => {
+  if (!a && !b) {
+    return false;
+  }
+  if (!a || !b) {
+    return true;
+  }
+  const widthA = a.width ?? 0;
+  const widthB = b.width ?? 0;
+  const heightA = a.height ?? 0;
+  const heightB = b.height ?? 0;
+  return (
+    Math.abs(a.x - b.x) > ANCHOR_EPSILON ||
+    Math.abs(a.y - b.y) > ANCHOR_EPSILON ||
+    Math.abs(widthA - widthB) > ANCHOR_EPSILON ||
+    Math.abs(heightA - heightB) > ANCHOR_EPSILON
+  );
+};
+
+export interface UseFrozenFloatingPlacementOptions {
+  anchor: FloatingMenuAnchorRect | null;
+  menuState: FloatingMenuPlacement;
+  menuSize: { width: number; height: number } | null;
+  viewportSize: { width: number; height: number };
+  pointerPosition: { x: number; y: number } | null;
+  options?: FloatingMenuPlacementOptions;
+  isVisible: boolean;
+  identity: string;
+}
+
+export interface UseFrozenFloatingPlacementResult {
+  placement: FloatingMenuPlacementResult | null;
+  orientation: FloatingMenuOrientation;
+  isFrozen: boolean;
+}
+
+export const useFrozenFloatingPlacement = ({
+  anchor,
+  menuState,
+  menuSize,
+  viewportSize,
+  pointerPosition,
+  options,
+  isVisible,
+  identity
+}: UseFrozenFloatingPlacementOptions): UseFrozenFloatingPlacementResult => {
+  const [frozenPlacement, setFrozenPlacement] = useState<FloatingMenuPlacementResult | null>(null);
+  const previousAnchorRef = useRef<FloatingMenuAnchorRect | null>(null);
+  const previousIdentityRef = useRef(identity);
+  const lastAnchoredPlacementRef = useRef<FloatingMenuPlacementResult | null>(null);
+
+  const basePlacement = useMemo(() => {
+    if (!anchor || menuState.isFree) {
+      return null;
+    }
+    const size = menuSize ?? { width: 0, height: 0 };
+    return computeFloatingMenuPlacement(anchor, size, viewportSize, pointerPosition, options);
+  }, [anchor, menuState.isFree, menuSize, viewportSize, pointerPosition, options]);
+
+  useEffect(() => {
+    if (!isVisible || menuState.isFree) {
+      if (frozenPlacement) {
+        setFrozenPlacement(null);
+      }
+      previousAnchorRef.current = cloneAnchor(anchor);
+      if (!isVisible) {
+        lastAnchoredPlacementRef.current = null;
+      }
+      return;
+    }
+
+    if (previousIdentityRef.current !== identity) {
+      previousIdentityRef.current = identity;
+      setFrozenPlacement(null);
+      previousAnchorRef.current = cloneAnchor(anchor);
+      return;
+    }
+
+    const previous = previousAnchorRef.current;
+    if (
+      anchor &&
+      previous &&
+      anchorsDiffer(previous, anchor) &&
+      !frozenPlacement &&
+      lastAnchoredPlacementRef.current
+    ) {
+      setFrozenPlacement(lastAnchoredPlacementRef.current);
+    }
+
+    previousAnchorRef.current = cloneAnchor(anchor);
+  }, [anchor, identity, isVisible, menuState.isFree, frozenPlacement]);
+
+  useEffect(() => {
+    if (basePlacement) {
+      lastAnchoredPlacementRef.current = basePlacement;
+    }
+  }, [basePlacement]);
+
+  useEffect(() => {
+    previousIdentityRef.current = identity;
+  }, [identity]);
+
+  const placement = frozenPlacement ?? basePlacement;
+  const orientation: FloatingMenuOrientation = menuState.isFree
+    ? frozenPlacement?.orientation ??
+      lastAnchoredPlacementRef.current?.orientation ??
+      basePlacement?.orientation ??
+      'top'
+    : placement?.orientation ?? 'top';
+
+  return {
+    placement,
+    orientation,
+    isFrozen: Boolean(frozenPlacement)
+  };
+};
+

--- a/src/state/sceneStore.ts
+++ b/src/state/sceneStore.ts
@@ -104,7 +104,8 @@ const defaultConnectorStyle: ConnectorModel['style'] = {
   startArrow: { shape: 'none', fill: 'filled' },
   endArrow: { shape: 'arrow', fill: 'filled' },
   arrowSize: 1,
-  cornerRadius: 12
+  cornerRadius: 12,
+  avoidNodes: true
 };
 
 const defaultConnectorLabelStyle: ConnectorLabelStyle = {

--- a/src/types/scene.ts
+++ b/src/types/scene.ts
@@ -83,6 +83,7 @@ export interface ConnectorStyle {
   endArrow?: ConnectorArrowStyle;
   arrowSize?: number;
   cornerRadius?: number;
+  avoidNodes?: boolean;
 }
 
 export interface ConnectorModel {


### PR DESCRIPTION
## Summary
- add obstacle-aware routing for elbow connectors with a default `avoidNodes` style flag and updated unit tests
- enlarge connector endpoints and pass node collections into connector geometry so paths can route around them
- introduce `useFrozenFloatingPlacement` and apply it to floating toolbars so they stay put while editing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d15f6a9c68832d81357a7f4a8f6310