### PR TITLE
Add node avoidance toggle and enforce connector clearance

### DIFF
--- a/src/components/ConnectorToolbar.tsx
+++ b/src/components/ConnectorToolbar.tsx
@@ -131,6 +131,8 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
     placementOptions
   ]);
 
+  // Connectors avoid nodes by default; only an explicit `false` opts into
+  // overlapping other shapes.
   const avoidNodesEnabled = connector.style.avoidNodes !== false;
 
   if (!isVisible || !anchor) {
@@ -245,14 +247,6 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
         >
           {connector.style.dashed ? 'Dashed' : 'Solid'}
         </button>
-        <button
-          type="button"
-          className={`connector-toolbar__button${avoidNodesEnabled ? ' is-active' : ''}`}
-          onClick={handleAvoidNodesToggle}
-          aria-pressed={avoidNodesEnabled}
-        >
-          {avoidNodesEnabled ? 'Avoid nodes' : 'Allow overlap'}
-        </button>
       </div>
       <div className="connector-toolbar__section">
         <label className="connector-toolbar__field">
@@ -343,6 +337,19 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
       <div className="connector-toolbar__section connector-toolbar__section--actions">
         <button type="button" className="connector-toolbar__button" onClick={onFlipDirection}>
           Flip
+        </button>
+        <button
+          type="button"
+          className={`connector-toolbar__button${avoidNodesEnabled ? '' : ' is-active'}`}
+          onClick={handleAvoidNodesToggle}
+          aria-pressed={!avoidNodesEnabled}
+        >
+          {/*
+            The label reflects the current avoidance mode so users can tell at
+            a glance whether connectors will hug nodes (Avoid On) or are
+            allowed to pass beneath them (Avoid Off).
+          */}
+          {avoidNodesEnabled ? 'Avoid On' : 'Avoid Off'}
         </button>
         <button type="button" className="connector-toolbar__button" onClick={onTidyPath}>
           Tidy


### PR DESCRIPTION
## Summary
- add documentation and move the connector avoidance toggle next to the Flip button with the new Avoid On/Avoid Off labelling
- expose a configurable CONNECTOR_NODE_AVOIDANCE_CLEARANCE constant and rework connector routing to respect padded obstacles
- extend connector routing tests with distance helpers to ensure a visible cushion remains around avoided nodes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d17c65ead8832d989a6c0681e4b7f3