### PR TITLE
Fix elbow connector routing when targets move behind source

### DIFF
--- a/src/utils/__tests__/connector.test.ts
+++ b/src/utils/__tests__/connector.test.ts
@@ -234,6 +234,21 @@ test('elbow connectors remain orthogonal and perpendicular at ports', () => {
   }
 });
 
+test('elbow connectors keep the outward stub when targets sit behind the source', () => {
+  const source = createNode('source', { x: 0, y: 0 }, { width: 200, height: 120 });
+  const target = createNode('target', { x: -120, y: 0 }, { width: 200, height: 120 });
+  const connector = createConnector('elbow', 'right', 'left');
+
+  const path = getConnectorPath(connector, source, target, [source, target]);
+
+  assert.ok(path.points.length >= 3, 'expected connector to include a stub segment');
+  const first = path.points[0];
+  const second = path.points[1];
+
+  assert.ok(Math.abs(second.y - first.y) < 1e-6, 'stub should remain horizontal');
+  assert.ok(second.x - first.x > 0, 'stub should extend outward from the right port');
+});
+
 test('straight connectors produce a single segment between ports', () => {
   const source = createNode('source', { x: 0, y: 0 });
   const target = createNode('target', { x: 320, y: 200 });

--- a/src/utils/connector.ts
+++ b/src/utils/connector.ts
@@ -1379,6 +1379,9 @@ export const getConnectorPath = (
   }
 
   if (connector.mode === 'elbow') {
+    enforcePortOrientation();
+    const reorthogonalized = ensureOrthogonalSegments(points);
+    points = sanitizePoints(reorthogonalized.map((point) => roundPoint(point)));
     for (let index = 0; index < points.length - 1; index += 1) {
       const current = points[index];
       const nextPoint = points[index + 1];


### PR DESCRIPTION
## Summary
- ensure elbow connector routing re-applies port orientation and re-orthogonalizes the polyline after avoidance adjustments
- add a regression test covering the case where the target node crosses behind the source node to keep the outward stub

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68d1ac8a73cc832d9b80d1f0112be2a8