### PR TITLE
Improve connector grab handles and label positioning

### DIFF
--- a/src/components/DiagramConnector.tsx
+++ b/src/components/DiagramConnector.tsx
@@ -26,7 +26,7 @@ interface DiagramConnectorProps {
   onCommitLabel: (value: string) => void;
   onCancelLabelEdit: () => void;
   onRequestLabelEdit: () => void;
-  onLabelPointerDown: (event: React.PointerEvent<SVGCircleElement>) => void;
+  onLabelPointerDown: (event: React.PointerEvent<Element>) => void;
 }
 
 const DEFAULT_LABEL_POSITION = 0.5;
@@ -406,7 +406,10 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
     if (labelEditing) {
       event.preventDefault();
       event.stopPropagation();
+      return;
     }
+    event.stopPropagation();
+    onLabelPointerDown(event);
   };
 
   const labelFontSize = connector.labelStyle?.fontSize ?? 14;
@@ -477,7 +480,7 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
                 className={`diagram-connector__segment-handle${isHovered ? ' is-hovered' : ''}`}
                 cx={centerX}
                 cy={centerY}
-                r={6}
+                r={7}
                 onPointerEnter={() => setHoveredSegment(segment.index)}
                 onPointerLeave={() =>
                   setHoveredSegment((value) => (value === segment.index ? null : value))

--- a/src/styles/canvas.css
+++ b/src/styles/canvas.css
@@ -143,7 +143,6 @@
 
 .diagram-connector.is-selected .diagram-connector__line {
   stroke: #60a5fa !important;
-  stroke-width: calc(var(--connector-width, 2) + 1.5);
   filter: drop-shadow(0 0 10px rgba(96, 165, 250, 0.35));
 }
 
@@ -162,12 +161,17 @@
   align-items: center;
   justify-content: center;
   user-select: none;
+  cursor: grab;
 }
 
 .diagram-connector__label.is-editing {
   user-select: text;
   cursor: text;
   outline: none;
+}
+
+.diagram-connector__label:not(.is-editing):active {
+  cursor: grabbing;
 }
 
 .diagram-connector__label[data-placeholder]:empty::before {
@@ -199,17 +203,19 @@
   stroke: #bfdbfe;
   stroke-width: 1.5;
   filter: drop-shadow(0 0 4px rgba(59, 130, 246, 0.35));
-  transition: transform 0.15s ease, fill 0.15s ease, stroke 0.15s ease;
+  transition: fill 0.15s ease, stroke 0.15s ease, filter 0.15s ease;
+  cursor: grab;
 }
 
 .diagram-connector__segment-handle.is-hovered {
-  transform: scale(1.1);
   fill: rgba(96, 165, 250, 0.95);
   stroke: #e0f2fe;
+  filter: drop-shadow(0 0 6px rgba(96, 165, 250, 0.4));
 }
 
 .diagram-connector__segment-handle:active {
-  transform: scale(0.95);
+  cursor: grabbing;
+  filter: drop-shadow(0 0 6px rgba(37, 99, 235, 0.45));
 }
 
 .diagram-connector__handle {
@@ -253,13 +259,13 @@
   filter: drop-shadow(0 2px 6px rgba(15, 23, 42, 0.45));
   transform-box: fill-box;
   transform-origin: center;
-  transition: transform 0.18s ease, opacity 0.18s ease, stroke 0.18s ease, fill 0.18s ease;
+  transition: opacity 0.18s ease, stroke 0.18s ease, fill 0.18s ease, filter 0.18s ease;
 }
 
 .diagram-connector__endpoint-visual.is-hovered {
-  transform: scale(1.12);
   opacity: 1;
   stroke: rgba(15, 23, 42, 0.6);
+  filter: drop-shadow(0 4px 10px rgba(59, 130, 246, 0.35));
 }
 
 .diagram-connector__endpoint-hit {
@@ -269,21 +275,20 @@
   cursor: grab;
   transform-box: fill-box;
   transform-origin: center;
-  transition: transform 0.18s ease, fill 0.18s ease, stroke 0.18s ease;
+  transition: fill 0.18s ease, stroke 0.18s ease, stroke-width 0.18s ease;
 }
 
 .diagram-connector__endpoint-hit.is-hovered {
   fill: rgba(59, 130, 246, 0.18);
   stroke: rgba(59, 130, 246, 0.7);
   stroke-width: 1.5;
-  transform: scale(1.12);
 }
 
 .diagram-connector__endpoint-hit.is-hovered:active {
   cursor: grabbing;
   fill: rgba(59, 130, 246, 0.28);
-  stroke: rgba(59, 130, 246, 0.8);
-  transform: scale(1.05);
+  stroke: rgba(59, 130, 246, 0.85);
+  stroke-width: 1.8;
 }
 
 .diagram-connector__label-leader {


### PR DESCRIPTION
## Summary
- keep connector endpoints and segment handles stationary on hover while still highlighting them
- stop selected connectors from changing width and add a draggable cursor for connector labels
- allow dragging connector labels directly on the text with snapping to common positions along the line

## Testing
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d1cae1db58832da356fcef622ded1b