### PR TITLE
Stabilize connector dragging preview

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -45,7 +45,8 @@ import {
   getNormalAtRatio,
   getPointAtRatio,
   measurePolyline,
-  tidyOrthogonalWaypoints
+  tidyOrthogonalWaypoints,
+  tidyOrthogonalWaypointsPreview
 } from '../utils/connector';
 import {
   selectConnectors,
@@ -214,6 +215,9 @@ interface ConnectorDragState {
     inserted: [number, number, number];
     axis: 'horizontal' | 'vertical';
   };
+  segmentStartSnapshot?: Vec2;
+  segmentEndSnapshot?: Vec2;
+  grabOffset?: Vec2;
 }
 
 interface ConnectorLabelDragState {
@@ -312,6 +316,7 @@ const CanvasComponent = (
   const setGlobalTransform = useSceneStore((state) => state.setTransform);
   const setEditingNode = useSceneStore((state) => state.setEditingNode);
   const equalizeSpacing = useSceneStore((state) => state.equalizeSpacing);
+  const setNodeLink = useSceneStore((state) => state.setNodeLink);
   const { applyStyles, setText } = useCommands();
 
   const selectedNodeIds = selection.nodeIds;
@@ -746,14 +751,18 @@ const CanvasComponent = (
   );
 
   const handleTextCommit = useCallback(
-    (value: string) => {
+    (value: string, metadata?: { linkUrl?: string }) => {
       if (editingNode) {
         setText(editingNode.id, value);
+        if (editingNode.shape === 'link') {
+          const url = metadata?.linkUrl?.trim() ?? '';
+          setNodeLink(editingNode.id, url.length ? url : null);
+        }
       }
       editingEntryPointRef.current = null;
       setEditingNode(null);
     },
-    [editingNode, setText, setEditingNode]
+    [editingNode, setNodeLink, setText, setEditingNode]
   );
 
   const handleTextCancel = useCallback(() => {
@@ -1246,6 +1255,11 @@ const CanvasComponent = (
       }
 
       const worldPoint = getWorldPoint(event);
+      const grabOffset = connectorDragState.grabOffset ?? { x: 0, y: 0 };
+      const pointerOnSegment = {
+        x: worldPoint.x - grabOffset.x,
+        y: worldPoint.y - grabOffset.y
+      };
       connectorDragState.moved = true;
 
       if (
@@ -1266,8 +1280,8 @@ const CanvasComponent = (
         } else {
           const offset =
             connectorDragState.axis === 'horizontal'
-              ? worldPoint.y - connectorDragState.initialPointer.y
-              : worldPoint.x - connectorDragState.initialPointer.x;
+              ? pointerOnSegment.y - connectorDragState.initialPointer.y
+              : pointerOnSegment.x - connectorDragState.initialPointer.x;
 
           if (connectorDragState.axis === 'horizontal') {
             nextPoints[pivotIndex] = {
@@ -1297,19 +1311,19 @@ const CanvasComponent = (
           const endPoint = nextPoints[nextPoints.length - 1];
           let interior = nextPoints.slice(1, nextPoints.length - 1);
           if (connectorDragState.mode === 'elbow') {
-            interior = tidyOrthogonalWaypoints(startPoint, interior, endPoint);
+            interior = tidyOrthogonalWaypointsPreview(startPoint, interior, endPoint);
           }
 
           const newBase = [
-            startPoint,
+            { ...startPoint },
             ...interior.map((point) => ({ ...point })),
-            endPoint
+            { ...endPoint }
           ];
 
-          connectorDragState.basePoints = newBase.map((point) => ({ ...point }));
-          connectorDragState.workingPoints = connectorDragState.basePoints.map((point) => ({ ...point }));
+          connectorDragState.basePoints = newBase;
+          connectorDragState.workingPoints = newBase.map((point) => ({ ...point }));
           connectorDragState.currentWaypoints = interior.map((point) => ({ ...point }));
-          connectorDragState.initialPointer = worldPoint;
+          connectorDragState.initialPointer = pointerOnSegment;
 
           const splitAxis = connectorDragState.split.axis;
           const anchorIdx = newBase.findIndex((point) => pointsRoughlyEqual(point, anchorSnapshot));
@@ -1318,11 +1332,24 @@ const CanvasComponent = (
 
           if (anchorIdx === -1 || pivotIdx === -1 || tailIdx === -1) {
             connectorDragState.split = undefined;
+            connectorDragState.segmentStartSnapshot = pivotSnapshot;
+            connectorDragState.segmentEndSnapshot = tailSnapshot;
           } else {
             connectorDragState.split = {
               inserted: [anchorIdx, pivotIdx, tailIdx],
               axis: splitAxis
             };
+            const startIndex = Math.min(pivotIdx, tailIdx);
+            const endIndex = Math.max(pivotIdx, tailIdx);
+            const resolvedAxis =
+              Math.abs(newBase[endIndex].x - newBase[startIndex].x) >=
+              Math.abs(newBase[endIndex].y - newBase[startIndex].y)
+                ? 'horizontal'
+                : 'vertical';
+            connectorDragState.segmentIndex = startIndex;
+            connectorDragState.axis = resolvedAxis;
+            connectorDragState.segmentStartSnapshot = { ...newBase[startIndex] };
+            connectorDragState.segmentEndSnapshot = { ...newBase[endIndex] };
           }
 
           updateConnector(connectorDragState.connectorId, {
@@ -1334,6 +1361,9 @@ const CanvasComponent = (
 
       const nextPoints = connectorDragState.basePoints.map((point) => ({ ...point }));
 
+      let trackedSegmentStart: Vec2 | null = null;
+      let trackedSegmentEnd: Vec2 | null = null;
+
       if (connectorDragState.kind === 'waypoint' && connectorDragState.waypointIndex !== undefined) {
         const index = connectorDragState.waypointIndex + 1;
         if (nextPoints[index]) {
@@ -1344,12 +1374,25 @@ const CanvasComponent = (
         connectorDragState.segmentIndex !== undefined &&
         connectorDragState.axis
       ) {
+        const startSnapshot = connectorDragState.segmentStartSnapshot;
+        const endSnapshot = connectorDragState.segmentEndSnapshot;
+
+        let startIndex = connectorDragState.segmentIndex;
+        let endIndex = Math.min(startIndex + 1, nextPoints.length - 1);
+
+        if (startSnapshot && endSnapshot) {
+          const startMatch = nextPoints.findIndex((point) => pointsRoughlyEqual(point, startSnapshot));
+          const endMatch = nextPoints.findIndex((point) => pointsRoughlyEqual(point, endSnapshot));
+          if (startMatch !== -1 && endMatch !== -1) {
+            startIndex = Math.min(startMatch, endMatch);
+            endIndex = Math.max(startMatch, endMatch);
+          }
+        }
+
         const offset =
           connectorDragState.axis === 'horizontal'
-            ? worldPoint.y - connectorDragState.initialPointer.y
-            : worldPoint.x - connectorDragState.initialPointer.x;
-        const startIndex = connectorDragState.segmentIndex;
-        const endIndex = Math.min(connectorDragState.segmentIndex + 1, nextPoints.length - 1);
+            ? pointerOnSegment.y - connectorDragState.initialPointer.y
+            : pointerOnSegment.x - connectorDragState.initialPointer.x;
         const applyOffset = (point: Vec2) =>
           connectorDragState.axis === 'horizontal'
             ? { ...point, y: point.y + offset }
@@ -1365,24 +1408,56 @@ const CanvasComponent = (
           nextPoints[startIndex] = applyOffset(nextPoints[startIndex]);
           nextPoints[endIndex] = applyOffset(nextPoints[endIndex]);
         }
+
+        trackedSegmentStart = nextPoints[startIndex] ? { ...nextPoints[startIndex] } : null;
+        trackedSegmentEnd = nextPoints[endIndex] ? { ...nextPoints[endIndex] } : null;
       }
 
       const startPoint = nextPoints[0];
       const endPoint = nextPoints[nextPoints.length - 1];
       let interior = nextPoints.slice(1, nextPoints.length - 1);
       if (connectorDragState.mode === 'elbow') {
-        interior = tidyOrthogonalWaypoints(startPoint, interior, endPoint);
+        interior =
+          connectorDragState.kind === 'segment'
+            ? tidyOrthogonalWaypointsPreview(startPoint, interior, endPoint)
+            : tidyOrthogonalWaypoints(startPoint, interior, endPoint);
       }
 
-      connectorDragState.basePoints = [
-        startPoint,
+      const base = [
+        { ...startPoint },
         ...interior.map((point) => ({ ...point })),
-        endPoint
+        { ...endPoint }
       ];
-      connectorDragState.workingPoints = connectorDragState.basePoints.map((point) => ({ ...point }));
+
+      connectorDragState.basePoints = base;
+      connectorDragState.workingPoints = base.map((point) => ({ ...point }));
       connectorDragState.currentWaypoints = interior.map((point) => ({ ...point }));
-      connectorDragState.initialPointer = worldPoint;
+      connectorDragState.initialPointer = connectorDragState.kind === 'segment' ? pointerOnSegment : worldPoint;
       connectorDragState.split = undefined;
+
+      if (
+        connectorDragState.kind === 'segment' &&
+        trackedSegmentStart &&
+        trackedSegmentEnd
+      ) {
+        const startMatch = base.findIndex((point) => pointsRoughlyEqual(point, trackedSegmentStart));
+        const endMatch = base.findIndex((point) => pointsRoughlyEqual(point, trackedSegmentEnd));
+        if (startMatch !== -1 && endMatch !== -1) {
+          const minIndex = Math.min(startMatch, endMatch);
+          const maxIndex = Math.max(startMatch, endMatch);
+          connectorDragState.segmentIndex = minIndex;
+          connectorDragState.axis =
+            Math.abs(base[maxIndex].x - base[minIndex].x) >=
+            Math.abs(base[maxIndex].y - base[minIndex].y)
+              ? 'horizontal'
+              : 'vertical';
+          connectorDragState.segmentStartSnapshot = { ...base[minIndex] };
+          connectorDragState.segmentEndSnapshot = { ...base[maxIndex] };
+        } else {
+          connectorDragState.segmentStartSnapshot = trackedSegmentStart;
+          connectorDragState.segmentEndSnapshot = trackedSegmentEnd;
+        }
+      }
 
       updateConnector(connectorDragState.connectorId, {
         points: connectorDragState.currentWaypoints
@@ -1546,7 +1621,18 @@ const CanvasComponent = (
         return null;
       }
       connectorDragStateRef.current = null;
-      const nextPoints = drag.moved ? drag.currentWaypoints : drag.originalWaypoints;
+      let nextPoints: Vec2[];
+      if (drag.moved) {
+        const working = drag.workingPoints.length ? drag.workingPoints : drag.basePoints;
+        const startPoint = working[0];
+        const endPoint = working[working.length - 1];
+        nextPoints = drag.currentWaypoints.map((point) => ({ ...point }));
+        if (drag.mode === 'elbow' && startPoint && endPoint) {
+          nextPoints = tidyOrthogonalWaypoints(startPoint, nextPoints, endPoint);
+        }
+      } else {
+        nextPoints = drag.originalWaypoints.map((point) => ({ ...point }));
+      }
       updateConnector(drag.connectorId, { points: nextPoints });
       endTransaction();
       releasePointerCapture(event.pointerId);
@@ -2151,7 +2237,15 @@ const CanvasComponent = (
         basePoints.splice(insertIndex, 0, anchorPoint, pivotPoint, tailPoint);
       }
 
+      const pivotIndex = insertIndex + 1;
+      const tailIndex = insertIndex + 2;
+      const pivotSnapshot = basePoints[pivotIndex] ? { ...basePoints[pivotIndex] } : undefined;
+      const tailSnapshot = basePoints[tailIndex] ? { ...basePoints[tailIndex] } : undefined;
       const interior = basePoints.slice(1, basePoints.length - 1).map((point) => ({ ...point }));
+      const grabOffset = {
+        x: worldPoint.x - closest.point.x,
+        y: worldPoint.y - closest.point.y
+      };
       connectorDragStateRef.current = {
         pointerId: event.pointerId,
         connectorId: connector.id,
@@ -2163,12 +2257,19 @@ const CanvasComponent = (
         workingPoints: basePoints.map((point) => ({ ...point })),
         originalWaypoints: connector.points?.map((point) => ({ ...point })) ?? [],
         currentWaypoints: interior,
-        initialPointer: worldPoint,
+        initialPointer: { ...closest.point },
         moved: false,
-        split: { inserted: [insertIndex, insertIndex + 1, insertIndex + 2], axis }
+        split: { inserted: [insertIndex, insertIndex + 1, insertIndex + 2], axis },
+        segmentStartSnapshot: pivotSnapshot,
+        segmentEndSnapshot: tailSnapshot,
+        grabOffset
       };
       updateConnector(connector.id, { points: interior });
     } else {
+      const grabOffset = {
+        x: worldPoint.x - closest.point.x,
+        y: worldPoint.y - closest.point.y
+      };
       connectorDragStateRef.current = {
         pointerId: event.pointerId,
         connectorId: connector.id,
@@ -2180,8 +2281,13 @@ const CanvasComponent = (
         workingPoints: basePoints.map((point) => ({ ...point })),
         originalWaypoints: connector.points?.map((point) => ({ ...point })) ?? [],
         currentWaypoints: connector.points?.map((point) => ({ ...point })) ?? [],
-        initialPointer: worldPoint,
-        moved: false
+        initialPointer: { ...closest.point },
+        moved: false,
+        segmentStartSnapshot: basePoints[index] ? { ...basePoints[index] } : undefined,
+        segmentEndSnapshot: basePoints[index + 1]
+          ? { ...basePoints[index + 1] }
+          : undefined,
+        grabOffset
       };
     }
     containerRef.current?.setPointerCapture(event.pointerId);

--- a/src/components/InlineTextEditor.tsx
+++ b/src/components/InlineTextEditor.tsx
@@ -16,7 +16,7 @@ interface InlineTextEditorProps {
   isEditing: boolean;
   scale: number;
   entryPoint: CaretPoint | null;
-  onCommit: (value: string) => void;
+  onCommit: (value: string, metadata?: { linkUrl?: string }) => void;
   onCancel: () => void;
   shouldIgnoreBlur?: () => boolean;
 }
@@ -41,9 +41,12 @@ const InlineTextEditorComponent = (
   ref: ForwardedRef<InlineTextEditorHandle>
 ) => {
   const editorRef = useRef<HTMLDivElement>(null);
+  const linkInputRef = useRef<HTMLInputElement | null>(null);
   const valueRef = useRef(node.text);
+  const linkValueRef = useRef(node.link?.url ?? '');
   const isComposingRef = useRef(false);
   const cancelledRef = useRef(false);
+  const isLinkNode = node.shape === 'link';
 
   const readCurrentValue = useCallback(() => {
     const element = editorRef.current;
@@ -53,11 +56,25 @@ const InlineTextEditorComponent = (
     return element.innerHTML;
   }, []);
 
+  const readCurrentLink = useCallback(() => {
+    const input = linkInputRef.current;
+    if (!input) {
+      return linkValueRef.current;
+    }
+    return input.value;
+  }, []);
+
   const commitValue = useCallback(() => {
     const text = readCurrentValue();
     valueRef.current = text;
-    onCommit(text);
-  }, [onCommit, readCurrentValue]);
+    if (isLinkNode) {
+      const link = readCurrentLink();
+      linkValueRef.current = link;
+      onCommit(text, { linkUrl: link });
+    } else {
+      onCommit(text);
+    }
+  }, [isLinkNode, onCommit, readCurrentLink, readCurrentValue]);
 
   const cancelEditing = useCallback(() => {
     cancelledRef.current = true;
@@ -85,6 +102,7 @@ const InlineTextEditorComponent = (
   useEffect(() => {
     if (!isEditing) {
       valueRef.current = node.text;
+      linkValueRef.current = node.link?.url ?? '';
       return;
     }
 
@@ -98,30 +116,43 @@ const InlineTextEditorComponent = (
     valueRef.current = node.text;
     element.innerHTML = node.text;
 
+    if (isLinkNode) {
+      const input = linkInputRef.current;
+      const currentUrl = node.link?.url ?? '';
+      linkValueRef.current = currentUrl;
+      if (input) {
+        input.value = currentUrl;
+      }
+    }
+
     const frame = requestAnimationFrame(() => {
       element.focus({ preventScroll: true });
       placeCaretAtPoint(element, entryPoint);
     });
 
     return () => cancelAnimationFrame(frame);
-  }, [isEditing, node.text, entryPoint]);
+  }, [entryPoint, isEditing, isLinkNode, node.link?.url, node.text]);
 
   if (!isEditing || !bounds) {
     return null;
   }
 
-  const isLinkNode = node.shape === 'link';
   const paddingTop = 6 * scale;
   const paddingBottom = 10 * scale;
   const paddingX = 14 * scale;
 
-  const style: React.CSSProperties = {
+  const containerStyle: React.CSSProperties = {
     position: 'absolute',
     left: bounds.x,
     top: bounds.y,
     width: bounds.width,
     height: bounds.height,
     padding: `${paddingTop}px ${paddingX}px ${paddingBottom}px`,
+    zIndex: 30,
+    background: 'transparent'
+  };
+
+  const contentStyle: React.CSSProperties = {
     fontSize: node.fontSize * scale,
     fontWeight: node.fontWeight,
     lineHeight: 1.3,
@@ -130,11 +161,10 @@ const InlineTextEditorComponent = (
     whiteSpace: 'normal',
     wordBreak: 'break-word',
     overflow: 'hidden',
-    background: 'transparent',
     caretColor: node.textColor,
-    zIndex: 30,
     fontStyle: isLinkNode ? 'italic' : undefined,
-    textDecoration: isLinkNode ? 'underline' : undefined
+    textDecoration: isLinkNode ? 'underline' : undefined,
+    background: 'transparent'
   };
 
   const handleInput = () => {
@@ -154,8 +184,12 @@ const InlineTextEditorComponent = (
     }
   };
 
-  const handleBlur = () => {
+  const handleBlur = (event: React.FocusEvent<HTMLDivElement>) => {
     if (isComposingRef.current || cancelledRef.current) {
+      return;
+    }
+    const related = event.relatedTarget as HTMLElement | null;
+    if (related && linkInputRef.current && related === linkInputRef.current) {
       return;
     }
     if (shouldIgnoreBlur?.()) {
@@ -173,27 +207,81 @@ const InlineTextEditorComponent = (
     valueRef.current = readCurrentValue();
   };
 
+  const handleLinkChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    linkValueRef.current = event.target.value;
+  };
+
+  const handleLinkKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter' && !event.shiftKey && !event.metaKey && !event.ctrlKey) {
+      event.preventDefault();
+      commitValue();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      cancelEditing();
+    }
+  };
+
+  const handleLinkBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    if (isComposingRef.current || cancelledRef.current) {
+      return;
+    }
+    const related = event.relatedTarget as HTMLElement | null;
+    if (related && editorRef.current && related === editorRef.current) {
+      return;
+    }
+    if (shouldIgnoreBlur?.()) {
+      return;
+    }
+    commitValue();
+  };
+
   return (
     <div
-      ref={editorRef}
       className={`inline-text-editor ${isLinkNode ? 'inline-text-editor--link' : ''}`.trim()}
-      style={style}
-      contentEditable
-      suppressContentEditableWarning
-      spellCheck={false}
-      translate="no"
-      role="textbox"
-      aria-multiline="true"
-      onInput={handleInput}
-      onKeyDown={handleKeyDown}
-      onBlur={handleBlur}
-      onCompositionStart={handleCompositionStart}
-      onCompositionEnd={handleCompositionEnd}
+      style={containerStyle}
       onPointerDown={(event) => event.stopPropagation()}
       onPointerMove={(event) => event.stopPropagation()}
       onPointerUp={(event) => event.stopPropagation()}
       onWheel={(event) => event.stopPropagation()}
-    />
+    >
+      <div
+        ref={editorRef}
+        className="inline-text-editor__content"
+        style={contentStyle}
+        contentEditable
+        suppressContentEditableWarning
+        spellCheck={false}
+        translate="no"
+        role="textbox"
+        aria-multiline="true"
+        onInput={handleInput}
+        onKeyDown={handleKeyDown}
+        onBlur={handleBlur}
+        onCompositionStart={handleCompositionStart}
+        onCompositionEnd={handleCompositionEnd}
+      />
+      {isLinkNode && (
+        <div className="inline-text-editor__link-field">
+          <input
+            ref={linkInputRef}
+            type="url"
+            className="inline-text-editor__link-input"
+            placeholder="https://example.com"
+            defaultValue={linkValueRef.current}
+            onChange={handleLinkChange}
+            onKeyDown={handleLinkKeyDown}
+            onBlur={handleLinkBlur}
+            onPointerDown={(event) => event.stopPropagation()}
+            onPointerMove={(event) => event.stopPropagation()}
+            onPointerUp={(event) => event.stopPropagation()}
+            onWheel={(event) => event.stopPropagation()}
+            spellCheck={false}
+            autoComplete="off"
+            aria-label="Link URL"
+          />
+        </div>
+      )}
+    </div>
   );
 };
 

--- a/src/styles/inline-text-editor.css
+++ b/src/styles/inline-text-editor.css
@@ -1,5 +1,18 @@
 .inline-text-editor {
   position: absolute;
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: inherit;
+  pointer-events: auto;
+  gap: 8px;
+}
+
+.inline-text-editor__content {
+  flex: 1 1 auto;
   display: block;
   box-sizing: border-box;
   border: none;
@@ -10,38 +23,64 @@
   pointer-events: auto;
   user-select: text;
   -webkit-user-modify: read-write;
+  min-height: 0;
 }
 
-.inline-text-editor:focus {
+.inline-text-editor__content:focus {
   outline: none;
 }
 
-.inline-text-editor::selection {
+.inline-text-editor__content::selection {
   background: rgba(96, 165, 250, 0.35);
 }
 
-.inline-text-editor a {
+.inline-text-editor__content a {
   color: #38bdf8;
   text-decoration: underline;
   font-style: italic;
 }
 
-.inline-text-editor--link {
+.inline-text-editor--link .inline-text-editor__content {
   font-style: italic !important;
   text-decoration: underline !important;
 }
 
-.inline-text-editor--link * {
+.inline-text-editor--link .inline-text-editor__content * {
   font-style: inherit !important;
   text-decoration: inherit !important;
 }
 
-.inline-text-editor ul,
-.inline-text-editor ol {
+.inline-text-editor__content ul,
+.inline-text-editor__content ol {
   margin: 0 0 0.5em;
   padding-left: 1.4em;
 }
 
-.inline-text-editor li {
+.inline-text-editor__content li {
   margin: 0.1em 0;
+}
+
+.inline-text-editor__link-field {
+  display: flex;
+  align-items: center;
+  pointer-events: auto;
+}
+
+.inline-text-editor__link-input {
+  flex: 1 1 auto;
+  box-sizing: border-box;
+  padding: 6px 10px;
+  border-radius: 6px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.85);
+  color: #e2e8f0;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  font-family: inherit;
+}
+
+.inline-text-editor__link-input:focus {
+  outline: none;
+  border-color: rgba(96, 165, 250, 0.8);
+  box-shadow: 0 0 0 1px rgba(96, 165, 250, 0.35);
 }

--- a/src/utils/connector.ts
+++ b/src/utils/connector.ts
@@ -724,6 +724,42 @@ const simplifyPolyline = (points: Vec2[]): Vec2[] => {
   return simplified;
 };
 
+export const tidyOrthogonalWaypointsPreview = (
+  start: Vec2,
+  waypoints: Vec2[],
+  end: Vec2
+): Vec2[] => {
+  if (!waypoints.length) {
+    return [];
+  }
+
+  const points = [start, ...waypoints.map((point) => clonePoint(point)), end];
+  const axes = computeSegmentAxes(points);
+
+  for (let index = 1; index < points.length - 1; index += 1) {
+    const prev = points[index - 1];
+    const next = points[index + 1];
+    const current = points[index];
+    const prevAxis = axes[index - 1] ?? axes[index] ?? 'horizontal';
+    const nextAxis = axes[index] ?? axes[index - 1] ?? 'horizontal';
+
+    if (prevAxis === 'horizontal') {
+      current.y = prev.y;
+    } else {
+      current.x = prev.x;
+    }
+
+    if (nextAxis === 'horizontal') {
+      current.y = next.y;
+    } else {
+      current.x = next.x;
+    }
+  }
+
+  const enforced = ensureOrthogonalSegments(points);
+  return enforced.slice(1, enforced.length - 1).map((point) => clonePoint(point));
+};
+
 export const tidyOrthogonalWaypoints = (start: Vec2, waypoints: Vec2[], end: Vec2): Vec2[] => {
   if (!waypoints.length) {
     return [];


### PR DESCRIPTION
## Summary
- keep connector segments anchored to the grabbed pointer location and avoid collapsing geometry while dragging
- add a lightweight waypoint tidy helper for drag previews and apply the full tidy only on commit

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68d3dab32fc8832dbf2970ffa06d30b9