### PR TITLE
Keep connector drag preview aligned with cursor

### DIFF
--- a/src/components/InlineTextEditor.tsx
+++ b/src/components/InlineTextEditor.tsx
@@ -16,7 +16,7 @@ interface InlineTextEditorProps {
   isEditing: boolean;
   scale: number;
   entryPoint: CaretPoint | null;
-  onCommit: (value: string) => void;
+  onCommit: (value: string, metadata?: { linkUrl?: string }) => void;
   onCancel: () => void;
   shouldIgnoreBlur?: () => boolean;
 }
@@ -41,9 +41,12 @@ const InlineTextEditorComponent = (
   ref: ForwardedRef<InlineTextEditorHandle>
 ) => {
   const editorRef = useRef<HTMLDivElement>(null);
+  const linkInputRef = useRef<HTMLInputElement | null>(null);
   const valueRef = useRef(node.text);
+  const linkValueRef = useRef(node.link?.url ?? '');
   const isComposingRef = useRef(false);
   const cancelledRef = useRef(false);
+  const isLinkNode = node.shape === 'link';
 
   const readCurrentValue = useCallback(() => {
     const element = editorRef.current;
@@ -53,11 +56,25 @@ const InlineTextEditorComponent = (
     return element.innerHTML;
   }, []);
 
+  const readCurrentLink = useCallback(() => {
+    const input = linkInputRef.current;
+    if (!input) {
+      return linkValueRef.current;
+    }
+    return input.value;
+  }, []);
+
   const commitValue = useCallback(() => {
     const text = readCurrentValue();
     valueRef.current = text;
-    onCommit(text);
-  }, [onCommit, readCurrentValue]);
+    if (isLinkNode) {
+      const link = readCurrentLink();
+      linkValueRef.current = link;
+      onCommit(text, { linkUrl: link });
+    } else {
+      onCommit(text);
+    }
+  }, [isLinkNode, onCommit, readCurrentLink, readCurrentValue]);
 
   const cancelEditing = useCallback(() => {
     cancelledRef.current = true;
@@ -85,6 +102,7 @@ const InlineTextEditorComponent = (
   useEffect(() => {
     if (!isEditing) {
       valueRef.current = node.text;
+      linkValueRef.current = node.link?.url ?? '';
       return;
     }
 
@@ -98,30 +116,43 @@ const InlineTextEditorComponent = (
     valueRef.current = node.text;
     element.innerHTML = node.text;
 
+    if (isLinkNode) {
+      const input = linkInputRef.current;
+      const currentUrl = node.link?.url ?? '';
+      linkValueRef.current = currentUrl;
+      if (input) {
+        input.value = currentUrl;
+      }
+    }
+
     const frame = requestAnimationFrame(() => {
       element.focus({ preventScroll: true });
       placeCaretAtPoint(element, entryPoint);
     });
 
     return () => cancelAnimationFrame(frame);
-  }, [isEditing, node.text, entryPoint]);
+  }, [entryPoint, isEditing, isLinkNode, node.link?.url, node.text]);
 
   if (!isEditing || !bounds) {
     return null;
   }
 
-  const isLinkNode = node.shape === 'link';
   const paddingTop = 6 * scale;
   const paddingBottom = 10 * scale;
   const paddingX = 14 * scale;
 
-  const style: React.CSSProperties = {
+  const containerStyle: React.CSSProperties = {
     position: 'absolute',
     left: bounds.x,
     top: bounds.y,
     width: bounds.width,
     height: bounds.height,
     padding: `${paddingTop}px ${paddingX}px ${paddingBottom}px`,
+    zIndex: 30,
+    background: 'transparent'
+  };
+
+  const contentStyle: React.CSSProperties = {
     fontSize: node.fontSize * scale,
     fontWeight: node.fontWeight,
     lineHeight: 1.3,
@@ -130,11 +161,10 @@ const InlineTextEditorComponent = (
     whiteSpace: 'normal',
     wordBreak: 'break-word',
     overflow: 'hidden',
-    background: 'transparent',
     caretColor: node.textColor,
-    zIndex: 30,
     fontStyle: isLinkNode ? 'italic' : undefined,
-    textDecoration: isLinkNode ? 'underline' : undefined
+    textDecoration: isLinkNode ? 'underline' : undefined,
+    background: 'transparent'
   };
 
   const handleInput = () => {
@@ -154,8 +184,12 @@ const InlineTextEditorComponent = (
     }
   };
 
-  const handleBlur = () => {
+  const handleBlur = (event: React.FocusEvent<HTMLDivElement>) => {
     if (isComposingRef.current || cancelledRef.current) {
+      return;
+    }
+    const related = event.relatedTarget as HTMLElement | null;
+    if (related && linkInputRef.current && related === linkInputRef.current) {
       return;
     }
     if (shouldIgnoreBlur?.()) {
@@ -173,27 +207,81 @@ const InlineTextEditorComponent = (
     valueRef.current = readCurrentValue();
   };
 
+  const handleLinkChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    linkValueRef.current = event.target.value;
+  };
+
+  const handleLinkKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter' && !event.shiftKey && !event.metaKey && !event.ctrlKey) {
+      event.preventDefault();
+      commitValue();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      cancelEditing();
+    }
+  };
+
+  const handleLinkBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    if (isComposingRef.current || cancelledRef.current) {
+      return;
+    }
+    const related = event.relatedTarget as HTMLElement | null;
+    if (related && editorRef.current && related === editorRef.current) {
+      return;
+    }
+    if (shouldIgnoreBlur?.()) {
+      return;
+    }
+    commitValue();
+  };
+
   return (
     <div
-      ref={editorRef}
       className={`inline-text-editor ${isLinkNode ? 'inline-text-editor--link' : ''}`.trim()}
-      style={style}
-      contentEditable
-      suppressContentEditableWarning
-      spellCheck={false}
-      translate="no"
-      role="textbox"
-      aria-multiline="true"
-      onInput={handleInput}
-      onKeyDown={handleKeyDown}
-      onBlur={handleBlur}
-      onCompositionStart={handleCompositionStart}
-      onCompositionEnd={handleCompositionEnd}
+      style={containerStyle}
       onPointerDown={(event) => event.stopPropagation()}
       onPointerMove={(event) => event.stopPropagation()}
       onPointerUp={(event) => event.stopPropagation()}
       onWheel={(event) => event.stopPropagation()}
-    />
+    >
+      <div
+        ref={editorRef}
+        className="inline-text-editor__content"
+        style={contentStyle}
+        contentEditable
+        suppressContentEditableWarning
+        spellCheck={false}
+        translate="no"
+        role="textbox"
+        aria-multiline="true"
+        onInput={handleInput}
+        onKeyDown={handleKeyDown}
+        onBlur={handleBlur}
+        onCompositionStart={handleCompositionStart}
+        onCompositionEnd={handleCompositionEnd}
+      />
+      {isLinkNode && (
+        <div className="inline-text-editor__link-field">
+          <input
+            ref={linkInputRef}
+            type="url"
+            className="inline-text-editor__link-input"
+            placeholder="https://example.com"
+            defaultValue={linkValueRef.current}
+            onChange={handleLinkChange}
+            onKeyDown={handleLinkKeyDown}
+            onBlur={handleLinkBlur}
+            onPointerDown={(event) => event.stopPropagation()}
+            onPointerMove={(event) => event.stopPropagation()}
+            onPointerUp={(event) => event.stopPropagation()}
+            onWheel={(event) => event.stopPropagation()}
+            spellCheck={false}
+            autoComplete="off"
+            aria-label="Link URL"
+          />
+        </div>
+      )}
+    </div>
   );
 };
 

--- a/src/state/sceneStore.ts
+++ b/src/state/sceneStore.ts
@@ -65,6 +65,10 @@ interface SceneStoreState {
   editingNodeId: string | null;
 }
 
+export interface UpdateConnectorOptions {
+  reroute?: boolean;
+}
+
 interface SceneStoreActions {
   setTool: (tool: Tool) => void;
   addNode: (type: NodeKind, position: Vec2) => NodeModel;
@@ -76,7 +80,11 @@ interface SceneStoreActions {
   ) => void;
   removeNode: (id: string) => void;
   addConnector: (source: ConnectorEndpoint, target: ConnectorEndpoint) => ConnectorModel | null;
-  updateConnector: (id: string, patch: Partial<ConnectorModel>) => void;
+  updateConnector: (
+    id: string,
+    patch: Partial<ConnectorModel>,
+    options?: UpdateConnectorOptions
+  ) => void;
   removeConnector: (id: string) => void;
   setSelection: (selection: SelectionState) => void;
   clearSelection: () => void;
@@ -434,8 +442,9 @@ export const useSceneStore = create<SceneStore>((set, get) => ({
 
     return connector;
   },
-  updateConnector: (id, patch) =>
+  updateConnector: (id, patch, options) =>
     set((current) => {
+      const { reroute = true } = options ?? {};
       const scene = cloneScene(current.scene);
       const index = scene.connectors.findIndex((item) => item.id === id);
       if (index === -1) {
@@ -472,7 +481,7 @@ export const useSceneStore = create<SceneStore>((set, get) => ({
 
       Object.assign(nextConnector, rest);
 
-      if (points) {
+      if (points && reroute) {
         const sourceNode = isAttachedConnectorEndpoint(nextConnector.source)
           ? scene.nodes.find((node) => node.id === nextConnector.source.nodeId)
           : undefined;

--- a/src/styles/inline-text-editor.css
+++ b/src/styles/inline-text-editor.css
@@ -1,5 +1,18 @@
 .inline-text-editor {
   position: absolute;
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: inherit;
+  pointer-events: auto;
+  gap: 8px;
+}
+
+.inline-text-editor__content {
+  flex: 1 1 auto;
   display: block;
   box-sizing: border-box;
   border: none;
@@ -10,38 +23,64 @@
   pointer-events: auto;
   user-select: text;
   -webkit-user-modify: read-write;
+  min-height: 0;
 }
 
-.inline-text-editor:focus {
+.inline-text-editor__content:focus {
   outline: none;
 }
 
-.inline-text-editor::selection {
+.inline-text-editor__content::selection {
   background: rgba(96, 165, 250, 0.35);
 }
 
-.inline-text-editor a {
+.inline-text-editor__content a {
   color: #38bdf8;
   text-decoration: underline;
   font-style: italic;
 }
 
-.inline-text-editor--link {
+.inline-text-editor--link .inline-text-editor__content {
   font-style: italic !important;
   text-decoration: underline !important;
 }
 
-.inline-text-editor--link * {
+.inline-text-editor--link .inline-text-editor__content * {
   font-style: inherit !important;
   text-decoration: inherit !important;
 }
 
-.inline-text-editor ul,
-.inline-text-editor ol {
+.inline-text-editor__content ul,
+.inline-text-editor__content ol {
   margin: 0 0 0.5em;
   padding-left: 1.4em;
 }
 
-.inline-text-editor li {
+.inline-text-editor__content li {
   margin: 0.1em 0;
+}
+
+.inline-text-editor__link-field {
+  display: flex;
+  align-items: center;
+  pointer-events: auto;
+}
+
+.inline-text-editor__link-input {
+  flex: 1 1 auto;
+  box-sizing: border-box;
+  padding: 6px 10px;
+  border-radius: 6px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.85);
+  color: #e2e8f0;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  font-family: inherit;
+}
+
+.inline-text-editor__link-input:focus {
+  outline: none;
+  border-color: rgba(96, 165, 250, 0.8);
+  box-shadow: 0 0 0 1px rgba(96, 165, 250, 0.35);
 }

--- a/src/utils/connector.ts
+++ b/src/utils/connector.ts
@@ -724,6 +724,42 @@ const simplifyPolyline = (points: Vec2[]): Vec2[] => {
   return simplified;
 };
 
+export const tidyOrthogonalWaypointsPreview = (
+  start: Vec2,
+  waypoints: Vec2[],
+  end: Vec2
+): Vec2[] => {
+  if (!waypoints.length) {
+    return [];
+  }
+
+  const points = [start, ...waypoints.map((point) => clonePoint(point)), end];
+  const axes = computeSegmentAxes(points);
+
+  for (let index = 1; index < points.length - 1; index += 1) {
+    const prev = points[index - 1];
+    const next = points[index + 1];
+    const current = points[index];
+    const prevAxis = axes[index - 1] ?? axes[index] ?? 'horizontal';
+    const nextAxis = axes[index] ?? axes[index - 1] ?? 'horizontal';
+
+    if (prevAxis === 'horizontal') {
+      current.y = prev.y;
+    } else {
+      current.x = prev.x;
+    }
+
+    if (nextAxis === 'horizontal') {
+      current.y = next.y;
+    } else {
+      current.x = next.x;
+    }
+  }
+
+  const enforced = ensureOrthogonalSegments(points);
+  return enforced.slice(1, enforced.length - 1).map((point) => clonePoint(point));
+};
+
 export const tidyOrthogonalWaypoints = (start: Vec2, waypoints: Vec2[], end: Vec2): Vec2[] => {
   if (!waypoints.length) {
     return [];


### PR DESCRIPTION
## Summary
- add an option to skip connector rerouting inside the scene store so in-progress edits can use raw waypoints
- feed live drag waypoints into DiagramConnector and Canvas so the rendered path matches the grab position during manipulation
- update connector drag flows to use preview points and bypass rerouting while dragging so segments track the cursor smoothly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d3dab32fc8832dbf2970ffa06d30b9