### PR TITLE
Enforce orthogonal connector edits and simplify elbow cleanup

### DIFF
--- a/src/components/ConnectorToolbar.tsx
+++ b/src/components/ConnectorToolbar.tsx
@@ -130,12 +130,6 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
     placementOptions
   ]);
 
-  // Connectors avoid nodes by default; only an explicit `false` opts into
-  // overlapping other shapes. Straight connectors ignore avoidance so that
-  // their geometry remains a single segment.
-  const isStraight = connector.mode === 'straight';
-  const avoidNodesEnabled = !isStraight && connector.style.avoidNodes !== false;
-
   if (!isVisible || !anchor) {
     return null;
   }
@@ -162,13 +156,6 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
 
   const handleDashToggle = () => {
     onStyleChange({ dashed: !connector.style.dashed });
-  };
-
-  const handleAvoidNodesToggle = () => {
-    if (isStraight) {
-      return;
-    }
-    onStyleChange({ avoidNodes: !avoidNodesEnabled });
   };
 
   const handleArrowChange = (key: 'startArrow' | 'endArrow', shape: ConnectorModel['style']['startArrow']) => {
@@ -362,18 +349,6 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
           <div className="connector-toolbar__actions">
             <button type="button" className="connector-toolbar__button" onClick={onFlipDirection}>
               Flip
-            </button>
-            <button
-              type="button"
-              className={`connector-toolbar__button${avoidNodesEnabled ? '' : ' is-active'}`}
-              onClick={handleAvoidNodesToggle}
-              aria-pressed={!avoidNodesEnabled}
-              disabled={isStraight}
-              title={
-                isStraight ? 'Straight connectors always allow lines to pass behind nodes.' : undefined
-              }
-            >
-              {avoidNodesEnabled ? 'Avoid On' : 'Avoid Off'}
             </button>
             <button type="button" className="connector-toolbar__button" onClick={onTidyPath}>
               Tidy

--- a/src/state/sceneStore.ts
+++ b/src/state/sceneStore.ts
@@ -114,8 +114,7 @@ const defaultConnectorStyle: ConnectorModel['style'] = {
   startArrow: { shape: 'none', fill: 'filled' },
   endArrow: { shape: 'arrow', fill: 'filled' },
   arrowSize: 1,
-  cornerRadius: 12,
-  avoidNodes: true
+  cornerRadius: 12
 };
 
 const defaultConnectorLabelStyle: ConnectorLabelStyle = {

--- a/src/types/scene.ts
+++ b/src/types/scene.ts
@@ -84,7 +84,6 @@ export interface ConnectorStyle {
   endArrow?: ConnectorArrowStyle;
   arrowSize?: number;
   cornerRadius?: number;
-  avoidNodes?: boolean;
 }
 
 export interface ConnectorModel {

--- a/src/utils/__tests__/connector.test.ts
+++ b/src/utils/__tests__/connector.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import {
   CARDINAL_PORTS,
   cloneConnectorEndpoint,
+  buildStraightConnectorBend,
   findClosestPointOnPolyline,
   getConnectorPath,
   getConnectorPortPositions,
@@ -42,8 +43,7 @@ const defaultConnectorStyle: Mutable<ConnectorModel['style']> = {
   startArrow: { shape: 'none', fill: 'filled' },
   endArrow: { shape: 'arrow', fill: 'filled' },
   arrowSize: 1,
-  cornerRadius: 12,
-  avoidNodes: false
+  cornerRadius: 12
 };
 
 const createConnector = (
@@ -112,6 +112,43 @@ test('elbow connectors create orthogonal paths with outward stubs', () => {
   }
 });
 
+test('aligned elbow connectors preserve outward stubs', () => {
+  const source = createNode('source', { x: 0, y: 120 });
+  const target = createNode('target', { x: 320, y: 120 });
+  const connector = createConnector('elbow', 'right', 'left');
+
+  const path = getConnectorPath(connector, source, target, [source, target]);
+  assert.strictEqual(path.points.length, 4, 'expected preserved stubs around aligned nodes');
+  const startStub = path.points[1];
+  const endStub = path.points[path.points.length - 2];
+  assert.ok(Math.abs(startStub.y - path.start.y) < 1e-3);
+  assert.ok(startStub.x > path.start.x);
+  assert.ok(Math.abs(endStub.y - path.end.y) < 1e-3);
+  assert.ok(endStub.x < path.end.x);
+});
+
+test('manual elbow waypoints stay aligned to endpoints', () => {
+  const originalSource = createNode('source', { x: 0, y: 0 });
+  const originalTarget = createNode('target', { x: 320, y: 200 });
+  const connector = createConnector('elbow', 'right', 'left');
+  connector.points = [
+    { x: 200, y: originalSource.position.y },
+    { x: 200, y: originalTarget.position.y }
+  ];
+
+  const movedSource = createNode('source', { x: 80, y: 60 });
+  const movedTarget = createNode('target', { x: 420, y: 280 });
+
+  const path = getConnectorPath(connector, movedSource, movedTarget, [movedSource, movedTarget]);
+  assert.ok(path.waypoints.length >= 2, 'expected preserved interior waypoints');
+  const first = path.waypoints[0];
+  const last = path.waypoints[path.waypoints.length - 1];
+  assert.ok(Math.abs(first.y - path.start.y) < 1e-3, 'first waypoint should align with source port');
+  assert.ok(first.x >= path.start.x, 'first waypoint should remain outward from the node');
+  assert.ok(Math.abs(last.y - path.end.y) < 1e-3, 'last waypoint should align with target port');
+  assert.ok(last.x <= path.end.x, 'last waypoint should remain outward from the node');
+});
+
 test('straight connectors connect ports directly', () => {
   const source = createNode('source', { x: 0, y: 0 });
   const target = createNode('target', { x: 320, y: 200 });
@@ -128,20 +165,82 @@ test('tidyOrthogonalWaypoints removes redundant points', () => {
   const end = { x: 100, y: 0 };
   const noisy = [
     { x: 20, y: 0 },
+    { x: 20, y: 0 },
+    { x: 40, y: 0 },
     { x: 40, y: 0 },
     { x: 40, y: 40 },
     { x: 60, y: 40 },
+    { x: 60, y: 0 },
     { x: 60, y: 0 },
     { x: 80, y: 0 }
   ];
 
   const cleaned = tidyOrthogonalWaypoints(start, noisy, end);
   assert.deepStrictEqual(cleaned, [
+    { x: 20, y: 0 },
     { x: 40, y: 0 },
     { x: 40, y: 40 },
     { x: 60, y: 40 },
-    { x: 60, y: 0 }
+    { x: 60, y: 0 },
+    { x: 80, y: 0 }
   ]);
+});
+
+test('tidyOrthogonalWaypoints removes 180 degree folds', () => {
+  const start = { x: 0, y: 0 };
+  const end = { x: 10, y: 120 };
+  const folded = [
+    { x: 60, y: 0 },
+    { x: 10, y: 0 },
+    { x: 10, y: 60 }
+  ];
+
+  const cleaned = tidyOrthogonalWaypoints(start, folded, end);
+  assert.deepStrictEqual(cleaned, [
+    { x: 10, y: 0 },
+    { x: 10, y: 60 }
+  ]);
+});
+
+test('tidyOrthogonalWaypoints collapses tight detours', () => {
+  const start = { x: 0, y: 0 };
+  const end = { x: 20, y: 160 };
+  const detour = [
+    { x: 60, y: 0 },
+    { x: 120, y: 0 },
+    { x: 120, y: 8 },
+    { x: 20, y: 8 },
+    { x: 20, y: 80 }
+  ];
+
+  const cleaned = tidyOrthogonalWaypoints(start, detour, end);
+  assert.deepStrictEqual(cleaned, [
+    { x: 20, y: 0 },
+    { x: 20, y: 80 }
+  ]);
+  for (let index = 0; index < cleaned.length - 1; index += 1) {
+    const a = index === 0 ? start : cleaned[index - 1];
+    const b = cleaned[index];
+    const c = cleaned[index + 1];
+    const firstAxis = Math.abs(a.x - b.x) < 1e-3 ? 'vertical' : 'horizontal';
+    const secondAxis = Math.abs(b.x - c.x) < 1e-3 ? 'vertical' : 'horizontal';
+    assert.ok(firstAxis !== secondAxis, 'turns should remain orthogonal');
+  }
+});
+
+test('buildStraightConnectorBend produces three right-angle turns', () => {
+  const start = { x: 100, y: 180 };
+  const end = { x: 420, y: 180 };
+  const waypoints = buildStraightConnectorBend(start, 'right', end, 'left', 60);
+
+  assert.strictEqual(waypoints.length, 4);
+  const [stubStart, pivotA, pivotB, stubEnd] = waypoints;
+  assert.ok(Math.abs(stubStart.y - start.y) < 1e-3);
+  assert.ok(stubStart.x > start.x);
+  assert.ok(Math.abs(pivotA.x - stubStart.x) < 1e-3);
+  assert.ok(Math.abs(pivotB.y - pivotA.y) < 1e-3);
+  assert.ok(Math.abs(stubEnd.y - end.y) < 1e-3);
+  assert.ok(stubEnd.x < end.x);
 });
 
 test('closest point on polyline identifies the nearest segment', () => {

--- a/src/utils/connector.ts
+++ b/src/utils/connector.ts
@@ -11,10 +11,9 @@ import {
 const EPSILON = 1e-6;
 const DEFAULT_STUB_LENGTH = 48;
 const MAX_PREVIEW_SNAP = 1e-3;
-
 export type ConnectorAxis = 'horizontal' | 'vertical' | 'diagonal';
 
-type ConnectorDirection = 'up' | 'down' | 'left' | 'right' | 'none';
+export type ConnectorDirection = 'up' | 'down' | 'left' | 'right' | 'none';
 
 type ResolvedEndpoint = {
   point: Vec2;
@@ -27,6 +26,12 @@ const directionForPort: Record<CardinalConnectorPort, ConnectorDirection> = {
   bottom: 'down',
   left: 'left'
 };
+
+export const getConnectorPortDirection = (port: CardinalConnectorPort): ConnectorDirection =>
+  directionForPort[port];
+
+export const getConnectorStubLength = (connector: ConnectorModel): number =>
+  connector.style.strokeWidth ? Math.max(36, connector.style.strokeWidth * 12) : DEFAULT_STUB_LENGTH;
 
 const clonePoint = (point: Vec2): Vec2 => ({ x: point.x, y: point.y });
 
@@ -51,7 +56,6 @@ const getNodeCenter = (node: NodeModel): Vec2 => ({
   x: node.position.x + node.size.width / 2,
   y: node.position.y + node.size.height / 2
 });
-
 export const CARDINAL_PORTS: CardinalConnectorPort[] = ['top', 'right', 'bottom', 'left'];
 
 const CARDINAL_PORT_LOOKUP = new Set<string>(CARDINAL_PORTS);
@@ -156,37 +160,129 @@ const buildDefaultWaypoints = (
     return [];
   }
 
-  const stubLength = connector.style.strokeWidth ? Math.max(36, connector.style.strokeWidth * 12) : DEFAULT_STUB_LENGTH;
-  const startStub = shouldAddStub(start.direction)
-    ? offsetPoint(start.point, start.direction, stubLength)
-    : clonePoint(start.point);
-  const endStub = shouldAddStub(end.direction)
-    ? offsetPoint(end.point, end.direction, stubLength)
-    : clonePoint(end.point);
+  const stubLength = getConnectorStubLength(connector);
+  const startHasStub = shouldAddStub(start.direction);
+  const endHasStub = shouldAddStub(end.direction);
+  const startStub = startHasStub ? offsetPoint(start.point, start.direction, stubLength) : clonePoint(start.point);
+  const endStub = endHasStub ? offsetPoint(end.point, end.direction, stubLength) : clonePoint(end.point);
 
   const waypoints: Vec2[] = [];
 
-  if (shouldAddStub(start.direction)) {
+  if (startHasStub) {
     waypoints.push(startStub);
   }
 
-  const bridgeNeeded =
-    !nearlyEqual(startStub.x, endStub.x) && !nearlyEqual(startStub.y, endStub.y);
+  const routeStart = startHasStub ? startStub : start.point;
+  const routeEnd = endHasStub ? endStub : end.point;
+
+  const bridgeNeeded = !nearlyEqual(routeStart.x, routeEnd.x) && !nearlyEqual(routeStart.y, routeEnd.y);
 
   if (bridgeNeeded) {
-    const horizontalFirst = Math.abs(endStub.x - startStub.x) >= Math.abs(endStub.y - startStub.y);
+    const horizontalFirst =
+      start.direction === 'left' || start.direction === 'right'
+        ? true
+        : start.direction === 'up' || start.direction === 'down'
+        ? false
+        : end.direction === 'up' || end.direction === 'down'
+        ? true
+        : end.direction === 'left' || end.direction === 'right'
+        ? false
+        : Math.abs(routeEnd.x - routeStart.x) >= Math.abs(routeEnd.y - routeStart.y);
+
     if (horizontalFirst) {
-      waypoints.push({ x: endStub.x, y: startStub.y });
+      waypoints.push({ x: routeEnd.x, y: routeStart.y });
     } else {
-      waypoints.push({ x: startStub.x, y: endStub.y });
+      waypoints.push({ x: routeStart.x, y: routeEnd.y });
     }
   }
 
-  if (shouldAddStub(end.direction)) {
+  if (endHasStub) {
     waypoints.push(endStub);
   }
 
   return waypoints.map(clonePoint);
+};
+
+const alignWaypointsToEndpoints = (
+  start: ResolvedEndpoint,
+  end: ResolvedEndpoint,
+  waypoints: Vec2[]
+): Vec2[] => {
+  if (!waypoints.length) {
+    return [];
+  }
+
+  const aligned = waypoints.map(clonePoint);
+
+  if (shouldAddStub(start.direction) && aligned[0]) {
+    const first = aligned[0];
+    if (start.direction === 'left' || start.direction === 'right') {
+      first.y = start.point.y;
+      if (start.direction === 'right' && first.x < start.point.x) {
+        first.x = start.point.x;
+      } else if (start.direction === 'left' && first.x > start.point.x) {
+        first.x = start.point.x;
+      }
+    } else {
+      first.x = start.point.x;
+      if (start.direction === 'down' && first.y < start.point.y) {
+        first.y = start.point.y;
+      } else if (start.direction === 'up' && first.y > start.point.y) {
+        first.y = start.point.y;
+      }
+    }
+  }
+
+  if (shouldAddStub(end.direction)) {
+    const lastIndex = aligned.length - 1;
+    if (lastIndex >= 0) {
+      const last = aligned[lastIndex];
+      if (end.direction === 'left' || end.direction === 'right') {
+        last.y = end.point.y;
+        if (end.direction === 'right' && last.x < end.point.x) {
+          last.x = end.point.x;
+        } else if (end.direction === 'left' && last.x > end.point.x) {
+          last.x = end.point.x;
+        }
+      } else {
+        last.x = end.point.x;
+        if (end.direction === 'down' && last.y < end.point.y) {
+          last.y = end.point.y;
+        } else if (end.direction === 'up' && last.y > end.point.y) {
+          last.y = end.point.y;
+        }
+      }
+    }
+  }
+
+  return aligned;
+};
+
+const getPerpendicularSign = (
+  orientation: 'horizontal' | 'vertical',
+  startDirection: ConnectorDirection,
+  endDirection: ConnectorDirection
+): number => {
+  const pick = (direction: ConnectorDirection) => {
+    if (orientation === 'horizontal') {
+      if (direction === 'up') {
+        return -1;
+      }
+      if (direction === 'down') {
+        return 1;
+      }
+    } else {
+      if (direction === 'left') {
+        return -1;
+      }
+      if (direction === 'right') {
+        return 1;
+      }
+    }
+    return 0;
+  };
+
+  return pick(startDirection) || pick(endDirection) || 1;
 };
 
 const stripDuplicateWaypoints = (waypoints: Vec2[]): Vec2[] => {
@@ -220,7 +316,8 @@ const mergeColinear = (points: Vec2[]): Vec2[] => {
     const next = points[index + 1];
     const horizontal = nearlyEqual(previous.y, current.y) && nearlyEqual(current.y, next.y);
     const vertical = nearlyEqual(previous.x, current.x) && nearlyEqual(current.x, next.x);
-    if (horizontal || vertical) {
+    const isEndpointAdjacent = merged.length === 1 || index === points.length - 2;
+    if ((horizontal || vertical) && !isEndpointAdjacent) {
       continue;
     }
     merged.push(clonePoint(current));
@@ -229,8 +326,176 @@ const mergeColinear = (points: Vec2[]): Vec2[] => {
   return merged;
 };
 
-export const tidyOrthogonalWaypoints = (start: Vec2, waypoints: Vec2[], end: Vec2): Vec2[] =>
-  mergeColinear([start, ...stripDuplicateWaypoints(waypoints), end]).slice(1, -1);
+const dedupePoints = (points: Vec2[]): Vec2[] => {
+  if (!points.length) {
+    return [];
+  }
+  const deduped: Vec2[] = [clonePoint(points[0])];
+  for (let index = 1; index < points.length; index += 1) {
+    const current = points[index];
+    const previous = deduped[deduped.length - 1];
+    if (nearlyEqual(previous.x, current.x) && nearlyEqual(previous.y, current.y)) {
+      continue;
+    }
+    deduped.push(clonePoint(current));
+  }
+  return deduped;
+};
+
+type OrthogonalAxis = 'horizontal' | 'vertical';
+
+const axisBetween = (start: Vec2, end: Vec2): OrthogonalAxis | null => {
+  if (nearlyEqual(start.x, end.x)) {
+    return 'vertical';
+  }
+  if (nearlyEqual(start.y, end.y)) {
+    return 'horizontal';
+  }
+  return null;
+};
+
+const removeAxisBacktracks = (points: Vec2[]): Vec2[] => {
+  if (points.length <= 2) {
+    return points.map(clonePoint);
+  }
+
+  const cleaned: Vec2[] = [clonePoint(points[0])];
+  for (let index = 1; index < points.length - 1; index += 1) {
+    const prev = cleaned[cleaned.length - 1];
+    const current = points[index];
+    const next = points[index + 1];
+    const prevAxis = axisBetween(prev, current);
+    const nextAxis = axisBetween(current, next);
+    const isFirstInterior = cleaned.length === 1;
+    const isLastInterior = index === points.length - 2;
+
+    if (prevAxis && nextAxis && prevAxis === nextAxis) {
+      const prevDelta = prevAxis === 'horizontal' ? current.x - prev.x : current.y - prev.y;
+      const nextDelta = nextAxis === 'horizontal' ? next.x - current.x : next.y - current.y;
+      const isFold =
+        prevDelta !== 0 && nextDelta !== 0 && Math.sign(prevDelta) !== Math.sign(nextDelta);
+      if (isFold || (!isFirstInterior && !isLastInterior)) {
+        continue;
+      }
+    }
+
+    cleaned.push(clonePoint(current));
+  }
+
+  cleaned.push(clonePoint(points[points.length - 1]));
+  return cleaned;
+};
+
+const MIN_DETOUR_SPAN = 12;
+
+const removeTightDetours = (points: Vec2[]): Vec2[] => {
+  if (points.length <= 3) {
+    return points.map(clonePoint);
+  }
+
+  const result = points.map(clonePoint);
+  let index = 1;
+  while (index < result.length - 2) {
+    const a = result[index - 1];
+    const b = result[index];
+    const c = result[index + 1];
+    const d = result[index + 2];
+    const axisAB = axisBetween(a, b);
+    const axisBC = axisBetween(b, c);
+    const axisCD = axisBetween(c, d);
+
+    if (axisAB && axisBC && axisCD && axisAB === axisCD && axisBC !== axisAB) {
+      const abDelta = axisAB === 'horizontal' ? b.x - a.x : b.y - a.y;
+      const cdDelta = axisCD === 'horizontal' ? d.x - c.x : d.y - c.y;
+      if (abDelta !== 0 && cdDelta !== 0 && Math.sign(abDelta) !== Math.sign(cdDelta)) {
+        const separation =
+          axisBC === 'horizontal' ? Math.abs(c.x - b.x) : Math.abs(c.y - b.y);
+        if (separation > 0 && separation <= MIN_DETOUR_SPAN) {
+          const pivot: Vec2 =
+            axisBC === 'vertical'
+              ? { x: d.x, y: b.y }
+              : { x: b.x, y: d.y };
+          const pivotDelta = axisAB === 'horizontal' ? pivot.x - a.x : pivot.y - a.y;
+          const pivotSign = Math.sign(pivotDelta);
+          const abSign = Math.sign(abDelta);
+          const nearStart = index === 1;
+          if (!nearStart || pivotSign === 0 || abSign === 0 || pivotSign === abSign) {
+            result.splice(index, 2, pivot);
+            if (index > 1) {
+              index -= 1;
+            }
+            continue;
+          }
+        }
+      }
+    }
+
+    index += 1;
+  }
+
+  return result;
+};
+
+export const tidyOrthogonalWaypoints = (start: Vec2, waypoints: Vec2[], end: Vec2): Vec2[] => {
+  const combined = [start, ...stripDuplicateWaypoints(waypoints), end];
+  let cleaned = dedupePoints(combined);
+  cleaned = removeAxisBacktracks(cleaned);
+  cleaned = dedupePoints(cleaned);
+  cleaned = removeTightDetours(cleaned);
+  cleaned = dedupePoints(cleaned);
+  cleaned = removeAxisBacktracks(cleaned);
+  cleaned = dedupePoints(cleaned);
+  cleaned = mergeColinear(cleaned);
+  cleaned = dedupePoints(cleaned);
+  return cleaned.slice(1, -1);
+};
+
+export const buildStraightConnectorBend = (
+  start: Vec2,
+  startDirection: ConnectorDirection,
+  end: Vec2,
+  endDirection: ConnectorDirection,
+  stubLength: number
+): Vec2[] => {
+  const orientation: 'horizontal' | 'vertical' =
+    Math.abs(start.y - end.y) <= Math.abs(start.x - end.x) ? 'horizontal' : 'vertical';
+
+  const magnitude = Math.max(12, Number.isFinite(stubLength) ? Math.abs(stubLength) : DEFAULT_STUB_LENGTH);
+  const startHasStub = shouldAddStub(startDirection);
+  const endHasStub = shouldAddStub(endDirection);
+  const startStub = startHasStub ? offsetPoint(start, startDirection, magnitude) : clonePoint(start);
+  const endStub = endHasStub ? offsetPoint(end, endDirection, magnitude) : clonePoint(end);
+
+  const sign = getPerpendicularSign(orientation, startDirection, endDirection);
+  const offset = magnitude * (sign === 0 ? 1 : sign);
+
+  const waypoints: Vec2[] = [];
+  if (startHasStub) {
+    waypoints.push(clonePoint(startStub));
+  }
+
+  if (orientation === 'horizontal') {
+    const referenceY = startHasStub ? startStub.y : start.y;
+    const pivotY = referenceY + offset;
+    const firstX = startHasStub ? startStub.x : start.x;
+    const lastX = endHasStub ? endStub.x : end.x;
+    waypoints.push({ x: firstX, y: pivotY });
+    waypoints.push({ x: lastX, y: pivotY });
+  } else {
+    const referenceX = startHasStub ? startStub.x : start.x;
+    const pivotX = referenceX + offset;
+    const firstY = startHasStub ? startStub.y : start.y;
+    const lastY = endHasStub ? endStub.y : end.y;
+    waypoints.push({ x: pivotX, y: firstY });
+    waypoints.push({ x: pivotX, y: lastY });
+  }
+
+  if (endHasStub) {
+    waypoints.push(clonePoint(endStub));
+  }
+
+  return tidyOrthogonalWaypoints(start, waypoints, end);
+};
 
 export interface ConnectorSegment {
   start: Vec2;
@@ -269,7 +534,11 @@ export const getConnectorPath = (
 
   const baseWaypoints = connector.points?.map(clonePoint) ?? [];
   const waypoints = baseWaypoints.length
-    ? stripDuplicateWaypoints(baseWaypoints)
+    ? alignWaypointsToEndpoints(
+        resolvedSource,
+        resolvedTarget,
+        stripDuplicateWaypoints(baseWaypoints)
+      )
     : buildDefaultWaypoints(connector, resolvedSource, resolvedTarget);
 
   const points = [resolvedSource.point, ...waypoints.map(clonePoint), resolvedTarget.point];


### PR DESCRIPTION
## Summary
- simplify connector routing utilities by keeping stubs, aligning saved waypoints to ports, and exposing a helper to seed orthogonal bends for straight segments
- let segment dragging on elbow connectors seed three-turn paths when the geometry is straight so users can reshape the line cleanly
- drop the avoid-nodes style flag and toolbar toggle now that connectors stay orthogonal by construction, and update tests to cover the new behavior
- lock elbow handle drags to a single axis and tidy orthogonal paths to eliminate 180° folds and tight detours with new regression tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d3fecd67d8832da38750d67d8a1897