### PR TITLE
Show link target in selection toolbar

### DIFF
--- a/src/components/SelectionToolbar.tsx
+++ b/src/components/SelectionToolbar.tsx
@@ -161,6 +161,7 @@ const SelectionToolbarContent: React.FC<SelectionToolbarContentProps> = ({
   const [textColorValue, setTextColorValue] = useState(node.textColor);
   const setNodeLink = useSceneStore((state) => state.setNodeLink);
   const [linkAddressValue, setLinkAddressValue] = useState(node.link?.url ?? '');
+  const linkUrl = (node.link?.url ?? '').trim();
 
   const {
     menuState,
@@ -977,6 +978,20 @@ const SelectionToolbarContent: React.FC<SelectionToolbarContentProps> = ({
                   </label>
                 </div>
               </>
+            )}
+            {isLinkNode && linkUrl && (
+              <div className="selection-toolbar__group selection-toolbar__group--link">
+                <span className="selection-toolbar__link-preview-label">Link</span>
+                <a
+                  className="selection-toolbar__link-preview"
+                  href={linkUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  translate="no"
+                >
+                  {linkUrl}
+                </a>
+              </div>
             )}
           </>
         )}

--- a/src/styles/selection-toolbar.css
+++ b/src/styles/selection-toolbar.css
@@ -218,6 +218,34 @@
   margin-left: calc(8px * var(--menu-scale));
 }
 
+.selection-toolbar__group--link {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: calc(6px * var(--menu-scale));
+  max-width: calc(260px * var(--menu-scale));
+}
+
+.selection-toolbar__link-preview-label {
+  font-size: calc(12px * var(--menu-scale));
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.82);
+  letter-spacing: 0.01em;
+}
+
+.selection-toolbar__link-preview {
+  color: #38bdf8;
+  text-decoration: none;
+  font-size: calc(13px * var(--menu-scale));
+  line-height: 1.35;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+
+.selection-toolbar__link-preview:hover,
+.selection-toolbar__link-preview:focus {
+  text-decoration: underline;
+}
+
 .selection-toolbar__link-address {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- display the saved link URL in the selection toolbar when selecting link nodes and open it in a new tab when clicked
- add styling for the link preview so it is readable within the floating menu

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d42430ffe0832da0a26db01729318c