### PR TITLE
Allow editing link text and align top/bottom connectors

### DIFF
--- a/src/components/DiagramNode.tsx
+++ b/src/components/DiagramNode.tsx
@@ -133,7 +133,10 @@ export const DiagramNode: React.FC<DiagramNodeProps> = ({
   const handleLabelPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
     const target = event.target as HTMLElement;
     if (target.closest('a')) {
-      event.stopPropagation();
+      if (event.detail === 1) {
+        event.stopPropagation();
+      }
+      return;
     }
   };
 

--- a/src/utils/__tests__/connector.test.ts
+++ b/src/utils/__tests__/connector.test.ts
@@ -181,9 +181,20 @@ test('straight connectors connect ports directly', () => {
   const connector = createConnector('straight', 'right', 'left');
 
   const path = getConnectorPath(connector, source, target, [source, target]);
-  assert.strictEqual(path.points.length, 2);
-  assert.deepStrictEqual(path.points[0], getConnectorPortPositions(source).right);
-  assert.deepStrictEqual(path.points[1], getConnectorPortPositions(target).left);
+  const sourcePort = getConnectorPortPositions(source).right;
+  const targetPort = getConnectorPortPositions(target).left;
+
+  assert.strictEqual(path.points.length, 4);
+  assert.deepStrictEqual(path.points[0], sourcePort);
+  assert.deepStrictEqual(path.points[path.points.length - 1], targetPort);
+
+  const startStub = path.points[1];
+  assert.ok(Math.abs(startStub.y - sourcePort.y) < 1e-3, 'expected start stub to stay horizontal');
+  assert.ok(startStub.x > sourcePort.x, 'expected start stub to extend outward from the node');
+
+  const endStub = path.points[path.points.length - 2];
+  assert.ok(Math.abs(endStub.y - targetPort.y) < 1e-3, 'expected end stub to stay horizontal');
+  assert.ok(endStub.x < targetPort.x, 'expected end stub to extend outward from the node');
 });
 
 test('tidyOrthogonalWaypoints removes redundant points', () => {

--- a/src/utils/connector.ts
+++ b/src/utils/connector.ts
@@ -156,10 +156,6 @@ const buildDefaultWaypoints = (
   start: ResolvedEndpoint,
   end: ResolvedEndpoint
 ): Vec2[] => {
-  if (connector.mode === 'straight') {
-    return [];
-  }
-
   const stubLength = getConnectorStubLength(connector);
   const startHasStub = shouldAddStub(start.direction);
   const endHasStub = shouldAddStub(end.direction);
@@ -172,27 +168,29 @@ const buildDefaultWaypoints = (
     waypoints.push(startStub);
   }
 
-  const routeStart = startHasStub ? startStub : start.point;
-  const routeEnd = endHasStub ? endStub : end.point;
+  if (connector.mode !== 'straight') {
+    const routeStart = startHasStub ? startStub : start.point;
+    const routeEnd = endHasStub ? endStub : end.point;
 
-  const bridgeNeeded = !nearlyEqual(routeStart.x, routeEnd.x) && !nearlyEqual(routeStart.y, routeEnd.y);
+    const bridgeNeeded = !nearlyEqual(routeStart.x, routeEnd.x) && !nearlyEqual(routeStart.y, routeEnd.y);
 
-  if (bridgeNeeded) {
-    const horizontalFirst =
-      start.direction === 'left' || start.direction === 'right'
-        ? true
-        : start.direction === 'up' || start.direction === 'down'
-        ? false
-        : end.direction === 'up' || end.direction === 'down'
-        ? true
-        : end.direction === 'left' || end.direction === 'right'
-        ? false
-        : Math.abs(routeEnd.x - routeStart.x) >= Math.abs(routeEnd.y - routeStart.y);
+    if (bridgeNeeded) {
+      const horizontalFirst =
+        start.direction === 'left' || start.direction === 'right'
+          ? true
+          : start.direction === 'up' || start.direction === 'down'
+          ? false
+          : end.direction === 'up' || end.direction === 'down'
+          ? true
+          : end.direction === 'left' || end.direction === 'right'
+          ? false
+          : Math.abs(routeEnd.x - routeStart.x) >= Math.abs(routeEnd.y - routeStart.y);
 
-    if (horizontalFirst) {
-      waypoints.push({ x: routeEnd.x, y: routeStart.y });
-    } else {
-      waypoints.push({ x: routeStart.x, y: routeEnd.y });
+      if (horizontalFirst) {
+        waypoints.push({ x: routeEnd.x, y: routeStart.y });
+      } else {
+        waypoints.push({ x: routeStart.x, y: routeEnd.y });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- allow double-click editing on link nodes by letting the second click on embedded links propagate
- keep straight connectors aligned with node ports by always adding stub segments for cardinal endpoints
- update connector tests to cover the new straight-connector behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d4679a0afc832d920a2529d33802ec