### PR TITLE
Restore vertical port directions and verify vertical stubs

### DIFF
--- a/src/components/DiagramNode.tsx
+++ b/src/components/DiagramNode.tsx
@@ -133,7 +133,10 @@ export const DiagramNode: React.FC<DiagramNodeProps> = ({
   const handleLabelPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
     const target = event.target as HTMLElement;
     if (target.closest('a')) {
-      event.stopPropagation();
+      if (event.detail === 1) {
+        event.stopPropagation();
+      }
+      return;
     }
   };
 

--- a/src/utils/__tests__/connector.test.ts
+++ b/src/utils/__tests__/connector.test.ts
@@ -181,9 +181,42 @@ test('straight connectors connect ports directly', () => {
   const connector = createConnector('straight', 'right', 'left');
 
   const path = getConnectorPath(connector, source, target, [source, target]);
-  assert.strictEqual(path.points.length, 2);
-  assert.deepStrictEqual(path.points[0], getConnectorPortPositions(source).right);
-  assert.deepStrictEqual(path.points[1], getConnectorPortPositions(target).left);
+  const sourcePort = getConnectorPortPositions(source).right;
+  const targetPort = getConnectorPortPositions(target).left;
+
+  assert.strictEqual(path.points.length, 4);
+  assert.deepStrictEqual(path.points[0], sourcePort);
+  assert.deepStrictEqual(path.points[path.points.length - 1], targetPort);
+
+  const startStub = path.points[1];
+  assert.ok(Math.abs(startStub.y - sourcePort.y) < 1e-3, 'expected start stub to stay horizontal');
+  assert.ok(startStub.x > sourcePort.x, 'expected start stub to extend outward from the node');
+
+  const endStub = path.points[path.points.length - 2];
+  assert.ok(Math.abs(endStub.y - targetPort.y) < 1e-3, 'expected end stub to stay horizontal');
+  assert.ok(endStub.x < targetPort.x, 'expected end stub to extend outward from the node');
+});
+
+test('straight connectors keep vertical stubs aligned to node edges', () => {
+  const source = createNode('source', { x: 200, y: 0 });
+  const target = createNode('target', { x: 200, y: 320 });
+  const connector = createConnector('straight', 'top', 'bottom');
+
+  const path = getConnectorPath(connector, source, target, [source, target]);
+  const sourcePort = getConnectorPortPositions(source).top;
+  const targetPort = getConnectorPortPositions(target).bottom;
+
+  assert.strictEqual(path.points.length, 4);
+  assert.deepStrictEqual(path.points[0], sourcePort);
+  assert.deepStrictEqual(path.points[path.points.length - 1], targetPort);
+
+  const startStub = path.points[1];
+  assert.ok(Math.abs(startStub.x - sourcePort.x) < 1e-3, 'expected start stub to stay vertical');
+  assert.ok(startStub.y < sourcePort.y, 'expected top port stub to extend above the node');
+
+  const endStub = path.points[path.points.length - 2];
+  assert.ok(Math.abs(endStub.x - targetPort.x) < 1e-3, 'expected end stub to stay vertical');
+  assert.ok(endStub.y > targetPort.y, 'expected bottom port stub to extend below the node');
 });
 
 test('tidyOrthogonalWaypoints removes redundant points', () => {

--- a/src/utils/connector.ts
+++ b/src/utils/connector.ts
@@ -156,10 +156,6 @@ const buildDefaultWaypoints = (
   start: ResolvedEndpoint,
   end: ResolvedEndpoint
 ): Vec2[] => {
-  if (connector.mode === 'straight') {
-    return [];
-  }
-
   const stubLength = getConnectorStubLength(connector);
   const startHasStub = shouldAddStub(start.direction);
   const endHasStub = shouldAddStub(end.direction);
@@ -172,27 +168,29 @@ const buildDefaultWaypoints = (
     waypoints.push(startStub);
   }
 
-  const routeStart = startHasStub ? startStub : start.point;
-  const routeEnd = endHasStub ? endStub : end.point;
+  if (connector.mode !== 'straight') {
+    const routeStart = startHasStub ? startStub : start.point;
+    const routeEnd = endHasStub ? endStub : end.point;
 
-  const bridgeNeeded = !nearlyEqual(routeStart.x, routeEnd.x) && !nearlyEqual(routeStart.y, routeEnd.y);
+    const bridgeNeeded = !nearlyEqual(routeStart.x, routeEnd.x) && !nearlyEqual(routeStart.y, routeEnd.y);
 
-  if (bridgeNeeded) {
-    const horizontalFirst =
-      start.direction === 'left' || start.direction === 'right'
-        ? true
-        : start.direction === 'up' || start.direction === 'down'
-        ? false
-        : end.direction === 'up' || end.direction === 'down'
-        ? true
-        : end.direction === 'left' || end.direction === 'right'
-        ? false
-        : Math.abs(routeEnd.x - routeStart.x) >= Math.abs(routeEnd.y - routeStart.y);
+    if (bridgeNeeded) {
+      const horizontalFirst =
+        start.direction === 'left' || start.direction === 'right'
+          ? true
+          : start.direction === 'up' || start.direction === 'down'
+          ? false
+          : end.direction === 'up' || end.direction === 'down'
+          ? true
+          : end.direction === 'left' || end.direction === 'right'
+          ? false
+          : Math.abs(routeEnd.x - routeStart.x) >= Math.abs(routeEnd.y - routeStart.y);
 
-    if (horizontalFirst) {
-      waypoints.push({ x: routeEnd.x, y: routeStart.y });
-    } else {
-      waypoints.push({ x: routeStart.x, y: routeEnd.y });
+      if (horizontalFirst) {
+        waypoints.push({ x: routeEnd.x, y: routeStart.y });
+      } else {
+        waypoints.push({ x: routeStart.x, y: routeEnd.y });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- restore the cardinal direction mapping so top ports point upward and bottom ports point downward again
- keep straight connector stubs enabled while updating the regression test to expect vertical stubs extend outward from the node edges

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d4679a0afc832d920a2529d33802ec