### PR TITLE
Add triangle-inward and circle start markers

### DIFF
--- a/src/components/ConnectorToolbar.tsx
+++ b/src/components/ConnectorToolbar.tsx
@@ -22,8 +22,8 @@ const TOOLBAR_OFFSET = 14;
 
 const arrowOptions = [
   { value: 'none', label: 'None' },
-  { value: 'triangle', label: 'Triangle (Inward)' },
   { value: 'arrow', label: 'Arrow' },
+  { value: 'triangle-inward', label: 'Triangle (Inward)' },
   { value: 'line-arrow', label: 'Line Arrow' },
   { value: 'diamond', label: 'Diamond' },
   { value: 'circle', label: 'Circle' }
@@ -45,7 +45,7 @@ const getLockedFillForShape = (
   if (shape === 'line-arrow') {
     return 'outlined';
   }
-  if (shape === 'triangle' || shape === 'arrow') {
+  if (shape === 'arrow') {
     return 'filled';
   }
   return null;

--- a/src/components/DiagramConnector.tsx
+++ b/src/components/DiagramConnector.tsx
@@ -54,11 +54,11 @@ const arrowPathForShape = (shape: ArrowShape, orientation: 'start' | 'end'): str
     case 'triangle-inward':
       return orientation === 'end'
         ? 'M12 1 L0 6 L12 11 Z'
-        : 'M0 1 L12 6 L0 11 Z';
+        : 'M12 1 L0 6 L12 11 Z';
     case 'arrow':
       return orientation === 'end'
         ? 'M0 1 L12 6 L0 11 Z'
-        : 'M12 1 L0 6 L12 11 Z';
+        : 'M0 1 L12 6 L0 11 Z';
     case 'line-arrow':
       return orientation === 'end'
         ? 'M0 1 L12 6 L0 11'

--- a/src/components/DiagramConnector.tsx
+++ b/src/components/DiagramConnector.tsx
@@ -51,6 +51,10 @@ const arrowPathForShape = (shape: ArrowShape, orientation: 'start' | 'end'): str
       return orientation === 'end'
         ? 'M12 1 L0 6 L12 11 Z'
         : 'M0 1 L12 6 L0 11 Z';
+    case 'triangle-inward':
+      return orientation === 'end'
+        ? 'M12 1 L0 6 L12 11 Z'
+        : 'M0 1 L12 6 L0 11 Z';
     case 'arrow':
       return orientation === 'end'
         ? 'M0 1 L12 6 L0 11 Z'
@@ -71,11 +75,15 @@ const arrowPathForShape = (shape: ArrowShape, orientation: 'start' | 'end'): str
 };
 
 const markerRefXForShape = (shape: ArrowShape, orientation: 'start' | 'end'): number => {
+  if (shape === 'circle') {
+    return 6;
+  }
+
   if (orientation === 'start') {
     return 0;
   }
 
-  if (shape === 'triangle') {
+  if (shape === 'triangle' || shape === 'triangle-inward') {
     return 0;
   }
 
@@ -91,7 +99,7 @@ const markerVisualsForShape = (
     return { fill: 'transparent', stroke: strokeColor, strokeWidth: 1.5 };
   }
 
-  if (shape === 'triangle' || shape === 'arrow') {
+  if (shape === 'arrow') {
     return { fill: strokeColor, stroke: 'none', strokeWidth: 0 };
   }
 
@@ -321,7 +329,7 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
           />
         ) : (
           <path
-            d={arrowPathForShape(shape, 'end') ?? ''}
+            d={arrowPathForShape(shape, orientation) ?? ''}
             fill={visuals.fill}
             stroke={visuals.stroke}
             strokeWidth={visuals.strokeWidth}

--- a/src/types/scene.ts
+++ b/src/types/scene.ts
@@ -61,7 +61,14 @@ export const isFloatingConnectorEndpoint = (
   endpoint: ConnectorEndpoint
 ): endpoint is FloatingConnectorEndpoint => 'position' in endpoint;
 
-export type ArrowShape = 'none' | 'triangle' | 'diamond' | 'circle' | 'arrow' | 'line-arrow';
+export type ArrowShape =
+  | 'none'
+  | 'triangle'
+  | 'triangle-inward'
+  | 'diamond'
+  | 'circle'
+  | 'arrow'
+  | 'line-arrow';
 export type ArrowFill = 'filled' | 'outlined';
 
 export interface ConnectorArrowStyle {


### PR DESCRIPTION
## Summary
- add a triangle-inward start arrow option and allow custom fills for non-line markers
- update connector rendering so triangle-inward and circle markers are drawn with correct geometry
- extend the arrow shape type to include the new triangle-inward option

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d4b456f45c832db9886ab601219046