### PR TITLE
Adjust triangle inward marker alignment

### DIFF
--- a/src/components/DiagramConnector.tsx
+++ b/src/components/DiagramConnector.tsx
@@ -79,11 +79,15 @@ const markerRefXForShape = (shape: ArrowShape, orientation: 'start' | 'end'): nu
     return 6;
   }
 
+  if (shape === 'triangle-inward') {
+    return 12;
+  }
+
   if (orientation === 'start') {
     return 0;
   }
 
-  if (shape === 'triangle' || shape === 'triangle-inward') {
+  if (shape === 'triangle') {
     return 0;
   }
 


### PR DESCRIPTION
## Summary
- shift the triangle-inward marker reference point so the base aligns with the connector grab point, ensuring visibility when selected

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d534302cb0832da383910774ab759d