### PR TITLE
Add image node with upload support

### DIFF
--- a/src/components/SelectionToolbar.tsx
+++ b/src/components/SelectionToolbar.tsx
@@ -29,7 +29,7 @@ const STROKE_MIN = 0;
 const STROKE_MAX = 20;
 const TOOLBAR_GAP = 12;
 
-const shapeOptions: Array<{ value: Exclude<NodeKind, 'text' | 'link'>; label: string }> = [
+const shapeOptions: Array<{ value: Exclude<NodeKind, 'text' | 'link' | 'image'>; label: string }> = [
   { value: 'circle', label: 'Circle' },
   { value: 'ellipse', label: 'Ellipse' },
   { value: 'rectangle', label: 'Rectangle' },

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -28,6 +28,30 @@ const SelectCursorIcon: React.FC = () => (
   </svg>
 );
 
+const ImageToolIcon: React.FC = () => (
+  <svg className="toolbar__icon-image" viewBox="0 0 24 24" aria-hidden>
+    <rect
+      x={3}
+      y={5}
+      width={18}
+      height={14}
+      rx={3}
+      fill="rgba(148, 163, 184, 0.35)"
+      stroke="#38bdf8"
+      strokeWidth={1.6}
+    />
+    <circle cx={9} cy={11} r={2.2} fill="#38bdf8" />
+    <path
+      d="M6 17.5L10.25 12.6a1.2 1.2 0 0 1 1.85-.02l1.7 1.94 2.1-2.32a1.2 1.2 0 0 1 1.8.02L21 16.5"
+      stroke="#38bdf8"
+      strokeWidth={1.6}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      fill="none"
+    />
+  </svg>
+);
+
 const nodeToolOptions = [
   { value: 'circle', label: 'Circle' },
   { value: 'ellipse', label: 'Ellipse' },
@@ -52,6 +76,7 @@ const toolButtons: Array<{
   { id: 'pan', label: 'Pan', icon: '✋', shortcut: 'Space', tooltip: 'Pan' },
   { id: 'text', label: 'Text box', icon: 'T', shortcut: 'T', tooltip: 'Text box' },
   { id: 'link', label: 'Link', icon: '🔗', tooltip: 'Link' },
+  { id: 'image', label: 'Image', icon: <ImageToolIcon />, tooltip: 'Image' },
   { id: 'connector', label: 'Connector', icon: '↦', shortcut: 'L', tooltip: 'Connector' }
 ];
 

--- a/src/styles/canvas.css
+++ b/src/styles/canvas.css
@@ -57,6 +57,31 @@
   transition: stroke 0.2s ease, stroke-width 0.2s ease;
 }
 
+.diagram-node__image-group {
+  pointer-events: none;
+}
+
+.diagram-node__image-frame {
+  fill: rgba(15, 23, 42, 0.85);
+  stroke: rgba(30, 41, 59, 0.6);
+}
+
+.diagram-node__image {
+  pointer-events: none;
+}
+
+.diagram-node__image-placeholder rect {
+  fill: rgba(15, 23, 42, 0.9);
+}
+
+.diagram-node__image-placeholder text {
+  fill: #cbd5f5;
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .diagram-node.is-selected .diagram-node__outline {
   filter: drop-shadow(0 0 12px rgba(96, 165, 250, 0.5));
 }
@@ -135,6 +160,10 @@
 }
 
 .diagram-node--text .diagram-node__shadow {
+  display: none;
+}
+
+.diagram-node--image .diagram-node__label {
   display: none;
 }
 

--- a/src/types/scene.ts
+++ b/src/types/scene.ts
@@ -1,5 +1,11 @@
 export type NodeShape = 'rectangle' | 'circle' | 'ellipse' | 'triangle' | 'diamond';
-export type NodeKind = NodeShape | 'text' | 'link';
+export interface NodeImageData {
+  src: string;
+  naturalWidth: number;
+  naturalHeight: number;
+}
+
+export type NodeKind = NodeShape | 'text' | 'link' | 'image';
 
 export interface Vec2 {
   x: number;
@@ -36,6 +42,7 @@ export interface NodeModel {
   cornerRadius?: number;
   link?: NodeLink;
   shadow?: boolean;
+  image?: NodeImageData;
 }
 
 export type ConnectorMode = 'elbow' | 'straight';
@@ -126,7 +133,8 @@ export type Tool =
   | 'diamond'
   | 'connector'
   | 'text'
-  | 'link';
+  | 'link'
+  | 'image';
 
 export interface CanvasTransform {
   x: number;

--- a/src/utils/__tests__/scene.test.ts
+++ b/src/utils/__tests__/scene.test.ts
@@ -4,7 +4,15 @@ import { createNodeModel } from '../scene';
 import type { NodeKind } from '../../types/scene';
 
 test('createNodeModel creates nodes with positive sizes for each shape', () => {
-  const shapes: NodeKind[] = ['rectangle', 'circle', 'ellipse', 'triangle', 'diamond', 'text'];
+  const shapes: NodeKind[] = [
+    'rectangle',
+    'circle',
+    'ellipse',
+    'triangle',
+    'diamond',
+    'text',
+    'image'
+  ];
   for (const shape of shapes) {
     const node = createNodeModel(shape, { x: 0, y: 0 });
     assert.strictEqual(node.shape, shape);

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -1,0 +1,29 @@
+export const readFileAsDataUrl = (file: File): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => {
+      reader.abort();
+      reject(new Error('Unable to read image file'));
+    };
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result === 'string') {
+        resolve(result);
+      } else {
+        reject(new Error('Unexpected image data format'));
+      }
+    };
+    reader.readAsDataURL(file);
+  });
+
+export const getImageDimensions = (src: string): Promise<{ width: number; height: number }> =>
+  new Promise((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => {
+      resolve({ width: image.naturalWidth, height: image.naturalHeight });
+    };
+    image.onerror = () => {
+      reject(new Error('Failed to load image'));
+    };
+    image.src = src;
+  });


### PR DESCRIPTION
## Summary
- add an image creation tool that lets users upload a file and place it on the canvas
- render the new image nodes with rounded previews and connector handles alongside selection styling
- update scene utilities, types, and store logic to persist image metadata while maintaining existing behaviors

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68d534f42378832daefb699bd1dc1569