### PR TITLE
Hide toolbars during multi-selection

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -691,11 +691,11 @@ const CanvasComponent = (
   };
 
   const selectedNode = useMemo(() => {
-    if (selectedNodeIds.length !== 1) {
+    if (selectedNodeIds.length !== 1 || selectedConnectorIds.length > 0) {
       return null;
     }
     return nodes.find((node) => node.id === selectedNodeIds[0]) ?? null;
-  }, [nodes, selectedNodeIds]);
+  }, [nodes, selectedNodeIds, selectedConnectorIds.length]);
 
   useEffect(() => {
     return () => {
@@ -704,11 +704,11 @@ const CanvasComponent = (
   }, [clearLinkActivationTimer]);
 
   const selectedConnector = useMemo(() => {
-    if (selectedConnectorIds.length !== 1) {
+    if (selectedConnectorIds.length !== 1 || selectedNodeIds.length > 0) {
       return null;
     }
     return connectors.find((item) => item.id === selectedConnectorIds[0]) ?? null;
-  }, [connectors, selectedConnectorIds]);
+  }, [connectors, selectedConnectorIds, selectedNodeIds.length]);
 
   useEffect(() => {
     const hasMenu = Boolean(selectedConnector) || Boolean(selectedNode);


### PR DESCRIPTION
## Summary
- stop treating nodes or connectors as individually selected when another item type is highlighted so floating menus stay hidden during multi-selection

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68d5490655d8832d83ad0e080bebb204