### PR TITLE
Add end connector arrow customization

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -118,6 +118,7 @@ const PENDING_CONNECTOR_STYLE: ConnectorModel['style'] = {
   strokeWidth: 2,
   dashed: false,
   startArrow: { shape: 'none', fill: 'filled' },
+  endArrow: { shape: 'none', fill: 'filled' },
   arrowSize: 1,
   cornerRadius: 12
 };
@@ -240,7 +241,8 @@ const cloneNodeForClipboard = (node: NodeModel): NodeModel => ({
 
 const cloneConnectorStyle = (style: ConnectorModel['style']): ConnectorModel['style'] => ({
   ...style,
-  startArrow: style.startArrow ? { ...style.startArrow } : undefined
+  startArrow: style.startArrow ? { ...style.startArrow } : undefined,
+  endArrow: style.endArrow ? { ...style.endArrow } : undefined
 });
 
 const cloneConnectorForClipboard = (connector: ConnectorModel): ConnectorModel => ({

--- a/src/components/ConnectorToolbar.tsx
+++ b/src/components/ConnectorToolbar.tsx
@@ -37,9 +37,10 @@ const modeOptions = [
   { value: 'straight', label: 'Straight' }
 ] as const;
 
-const getLockedFillForShape = (
-  shape: ConnectorModel['style']['startArrow']['shape']
-): ConnectorModel['style']['startArrow']['fill'] | null => {
+type ArrowShapeValue = NonNullable<ConnectorModel['style']['startArrow']>['shape'];
+type ArrowFillValue = NonNullable<ConnectorModel['style']['startArrow']>['fill'];
+
+const getLockedFillForShape = (shape: ArrowShapeValue): ArrowFillValue | null => {
   if (shape === 'line-arrow') {
     return 'outlined';
   }
@@ -135,6 +136,11 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
   const startFillDisabled = startLockedFill !== null;
   const startFillValue = startLockedFill ?? connector.style.startArrow?.fill ?? 'filled';
 
+  const endShape = connector.style.endArrow?.shape ?? 'none';
+  const endLockedFill = getLockedFillForShape(endShape);
+  const endFillDisabled = endLockedFill !== null;
+  const endFillValue = endLockedFill ?? connector.style.endArrow?.fill ?? 'filled';
+
   const handleStrokeWidthChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = Number(event.target.value);
     if (Number.isFinite(value)) {
@@ -155,7 +161,7 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
   };
 
   const handleStartArrowShapeChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    const shape = event.target.value as ConnectorModel['style']['startArrow']['shape'];
+    const shape = event.target.value as ArrowShapeValue;
     const current = connector.style.startArrow ?? { shape: 'none', fill: 'filled' };
     const lockedFill = getLockedFillForShape(shape);
     const nextFill = lockedFill ?? current.fill ?? 'filled';
@@ -167,9 +173,31 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
     if (currentShape && getLockedFillForShape(currentShape)) {
       return;
     }
-    const fill = event.target.value as ConnectorModel['style']['startArrow']['fill'];
+    const fill = event.target.value as ArrowFillValue;
     const current = connector.style.startArrow ?? { shape: 'none', fill: 'filled' };
     handleStartArrowChange({ ...current, fill });
+  };
+
+  const handleEndArrowChange = (shape: ConnectorModel['style']['endArrow']) => {
+    onStyleChange({ endArrow: shape });
+  };
+
+  const handleEndArrowShapeChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const shape = event.target.value as ArrowShapeValue;
+    const current = connector.style.endArrow ?? { shape: 'none', fill: 'filled' };
+    const lockedFill = getLockedFillForShape(shape);
+    const nextFill = lockedFill ?? current.fill ?? 'filled';
+    handleEndArrowChange({ ...current, shape, fill: nextFill });
+  };
+
+  const handleEndArrowFillChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const currentShape = connector.style.endArrow?.shape;
+    if (currentShape && getLockedFillForShape(currentShape)) {
+      return;
+    }
+    const fill = event.target.value as ArrowFillValue;
+    const current = connector.style.endArrow ?? { shape: 'none', fill: 'filled' };
+    handleEndArrowChange({ ...current, fill });
   };
 
   const handleArrowSizeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -264,6 +292,46 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
                 value={startFillValue}
                 onChange={handleStartArrowFillChange}
                 disabled={startFillDisabled}
+              >
+                {fillOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+        </section>
+        <section className="connector-toolbar__panel connector-toolbar__panel--end">
+          <h3 className="connector-toolbar__panel-title">End</h3>
+          <div className="connector-toolbar__section">
+            <label className="connector-toolbar__field connector-toolbar__field--block">
+              <span>Size</span>
+              <input
+                type="range"
+                min={0.5}
+                max={4}
+                step={0.1}
+                value={connector.style.arrowSize ?? 1}
+                onChange={handleArrowSizeChange}
+              />
+            </label>
+            <label className="connector-toolbar__field">
+              <span>Shape</span>
+              <select value={endShape} onChange={handleEndArrowShapeChange}>
+                {arrowOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="connector-toolbar__field">
+              <span>Fill</span>
+              <select
+                value={endFillValue}
+                onChange={handleEndArrowFillChange}
+                disabled={endFillDisabled}
               >
                 {fillOptions.map((option) => (
                   <option key={option.value} value={option.value}>

--- a/src/components/DiagramConnector.tsx
+++ b/src/components/DiagramConnector.tsx
@@ -289,10 +289,15 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
   const endpointColor = connector.style.stroke;
   const arrowSize = Math.max(0.6, connector.style.arrowSize ?? 1);
   const startMarkerId = useMemo(() => `connector-${connector.id}-start`, [connector.id]);
+  const endMarkerId = useMemo(() => `connector-${connector.id}-end`, [connector.id]);
 
   const startArrowShape = connector.style.startArrow?.shape ?? 'none';
   const startArrowFill =
     startArrowShape === 'line-arrow' ? 'outlined' : connector.style.startArrow?.fill ?? 'filled';
+
+  const endArrowShape = connector.style.endArrow?.shape ?? 'none';
+  const endArrowFill =
+    endArrowShape === 'line-arrow' ? 'outlined' : connector.style.endArrow?.fill ?? 'filled';
 
   const createMarker = (
     markerId: string,
@@ -346,6 +351,7 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
   };
 
   const startMarker = createMarker(startMarkerId, startArrowShape, startArrowFill, 'start');
+  const endMarker = createMarker(endMarkerId, endArrowShape, endArrowFill, 'end');
 
   const handleLabelInput = (event: React.FormEvent<HTMLDivElement>) => {
     setDraft(event.currentTarget.textContent ?? '');
@@ -459,6 +465,7 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
   const labelBackground = connector.labelStyle?.background ?? 'rgba(15,23,42,0.85)';
 
   const markerStartUrl = startArrowShape !== 'none' ? `url(#${startMarkerId})` : undefined;
+  const markerEndUrl = endArrowShape !== 'none' ? `url(#${endMarkerId})` : undefined;
 
   const trimmedLabel = connector.label?.trim() ?? '';
   const hasLabel = Boolean(trimmedLabel) || labelEditing;
@@ -490,7 +497,10 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
         ['--connector-width' as string]: `${connector.style.strokeWidth}`
       } as React.CSSProperties}
     >
-      <defs>{startMarker}</defs>
+      <defs>
+        {startMarker}
+        {endMarker}
+      </defs>
       <path className="diagram-connector__hit" d={hitPathData} strokeWidth={28} onPointerDown={onPointerDown} />
       {segments.map((segment) => {
         const isHovered = hoveredSegment === segment.index;
@@ -543,6 +553,7 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
         strokeWidth={connector.style.strokeWidth}
         strokeDasharray={connector.style.dashed ? '12 8' : undefined}
         markerStart={markerStartUrl}
+        markerEnd={markerEndUrl}
         onPointerDown={onPointerDown}
       />
       {selected && (

--- a/src/state/sceneStore.ts
+++ b/src/state/sceneStore.ts
@@ -114,9 +114,16 @@ const defaultConnectorStyle: ConnectorModel['style'] = {
   strokeWidth: 2,
   dashed: false,
   startArrow: { shape: 'none', fill: 'filled' },
+  endArrow: { shape: 'none', fill: 'filled' },
   arrowSize: 1,
   cornerRadius: 12
 };
+
+const cloneConnectorStyle = (style: ConnectorModel['style']): ConnectorModel['style'] => ({
+  ...style,
+  startArrow: style.startArrow ? { ...style.startArrow } : undefined,
+  endArrow: style.endArrow ? { ...style.endArrow } : undefined
+});
 
 const defaultConnectorLabelStyle: ConnectorLabelStyle = {
   fontSize: 14,
@@ -137,7 +144,7 @@ const createInitialScene = (): SceneContent => {
       mode: 'elbow',
       source: { nodeId: start.id, port: 'right' },
       target: { nodeId: collect.id, port: 'left' },
-      style: { ...defaultConnectorStyle },
+      style: cloneConnectorStyle(defaultConnectorStyle),
       label: 'Begin',
       labelPosition: 0.5,
       labelOffset: 18,
@@ -148,7 +155,7 @@ const createInitialScene = (): SceneContent => {
       mode: 'elbow',
       source: { nodeId: collect.id, port: 'right' },
       target: { nodeId: decision.id, port: 'left' },
-      style: { ...defaultConnectorStyle },
+      style: cloneConnectorStyle(defaultConnectorStyle),
       labelPosition: 0.5,
       labelOffset: 18,
       labelStyle: { ...defaultConnectorLabelStyle }
@@ -158,7 +165,7 @@ const createInitialScene = (): SceneContent => {
       mode: 'elbow',
       source: { nodeId: decision.id, port: 'right' },
       target: { nodeId: done.id, port: 'left' },
-      style: { ...defaultConnectorStyle },
+      style: cloneConnectorStyle(defaultConnectorStyle),
       label: 'Yes',
       labelPosition: 0.5,
       labelOffset: 18,
@@ -248,10 +255,7 @@ export const useSceneStore = create<SceneStore>((set, get) => ({
           ...connector,
           source: cloneConnectorEndpoint(connector.source),
           target: cloneConnectorEndpoint(connector.target),
-          style: {
-            ...connector.style,
-            startArrow: connector.style.startArrow ? { ...connector.style.startArrow } : undefined
-          },
+          style: cloneConnectorStyle(connector.style),
           labelStyle: connector.labelStyle ? { ...connector.labelStyle } : undefined,
           points: connector.points?.map((point) => ({ ...point }))
         };
@@ -474,7 +478,7 @@ export const useSceneStore = create<SceneStore>((set, get) => ({
       mode: 'elbow',
       source,
       target,
-      style: { ...defaultConnectorStyle },
+      style: cloneConnectorStyle(defaultConnectorStyle),
       labelPosition: 0.5,
       labelOffset: 18,
       labelStyle: { ...defaultConnectorLabelStyle }
@@ -485,7 +489,8 @@ export const useSceneStore = create<SceneStore>((set, get) => ({
       scene.connectors.push({
         ...connector,
         source: cloneConnectorEndpoint(connector.source),
-        target: cloneConnectorEndpoint(connector.target)
+        target: cloneConnectorEndpoint(connector.target),
+        style: cloneConnectorStyle(connector.style)
       });
       return {
         ...withSceneChange(current, scene),
@@ -511,7 +516,7 @@ export const useSceneStore = create<SceneStore>((set, get) => ({
         ...existing,
         source: cloneConnectorEndpoint(existing.source),
         target: cloneConnectorEndpoint(existing.target),
-        style: { ...existing.style },
+        style: cloneConnectorStyle(existing.style),
         labelStyle: existing.labelStyle ? { ...existing.labelStyle } : undefined,
         points: existing.points?.map((point) => ({ ...point }))
       };
@@ -519,7 +524,14 @@ export const useSceneStore = create<SceneStore>((set, get) => ({
       const { style, points, labelStyle, source, target, ...rest } = patch;
 
       if (style) {
-        nextConnector.style = { ...nextConnector.style, ...style };
+        const { startArrow, endArrow, ...restStyle } = style;
+        nextConnector.style = { ...nextConnector.style, ...restStyle };
+        if (startArrow !== undefined) {
+          nextConnector.style.startArrow = startArrow ? { ...startArrow } : undefined;
+        }
+        if (endArrow !== undefined) {
+          nextConnector.style.endArrow = endArrow ? { ...endArrow } : undefined;
+        }
       }
       if (labelStyle !== undefined) {
         nextConnector.labelStyle = labelStyle ? { ...labelStyle } : undefined;

--- a/src/types/scene.ts
+++ b/src/types/scene.ts
@@ -95,6 +95,7 @@ export interface ConnectorStyle {
   strokeWidth: number;
   dashed?: boolean;
   startArrow?: ConnectorArrowStyle;
+  endArrow?: ConnectorArrowStyle;
   arrowSize?: number;
   cornerRadius?: number;
 }

--- a/src/utils/__tests__/connector.test.ts
+++ b/src/utils/__tests__/connector.test.ts
@@ -41,6 +41,7 @@ const defaultConnectorStyle: Mutable<ConnectorModel['style']> = {
   strokeWidth: 2,
   dashed: false,
   startArrow: { shape: 'none', fill: 'filled' },
+  endArrow: { shape: 'none', fill: 'filled' },
   arrowSize: 1,
   cornerRadius: 12
 };


### PR DESCRIPTION
## Summary
- add an `endArrow` style to connectors and ensure default styles and clones include both ends
- allow the connector toolbar to configure the end arrow just like the start arrow
- render end arrow markers using the saved style information

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68d5525e9a08832db3be058fbb70b407