### PR TITLE
Fix connector end size scaling

### DIFF
--- a/src/components/DiagramConnector.tsx
+++ b/src/components/DiagramConnector.tsx
@@ -288,6 +288,7 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
   const arrowStroke = connector.style.stroke;
   const endpointColor = connector.style.stroke;
   const arrowSize = Math.max(0.6, connector.style.arrowSize ?? 1);
+  const markerSize = 24 * arrowSize;
   const startMarkerId = useMemo(() => `connector-${connector.id}-start`, [connector.id]);
 
   const startArrowShape = connector.style.startArrow?.shape ?? 'none';
@@ -315,12 +316,12 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
       <marker
         id={markerId}
         viewBox="0 0 12 12"
-        markerWidth={12 * arrowSize}
-        markerHeight={12 * arrowSize}
+        markerWidth={markerSize}
+        markerHeight={markerSize}
         refX={refX}
         refY={6}
         orient="auto-start-reverse"
-        markerUnits="strokeWidth"
+        markerUnits="userSpaceOnUse"
       >
         {shape === 'circle' ? (
           <circle

--- a/src/utils/__tests__/connector.test.ts
+++ b/src/utils/__tests__/connector.test.ts
@@ -123,6 +123,35 @@ test('aligned connectors preserve outward stubs', () => {
   assert.ok(endStub.x < path.end.x);
 });
 
+test('connector stub length is controlled by arrow size instead of stroke width', () => {
+  const source = createNode('source', { x: 0, y: 120 });
+  const target = createNode('target', { x: 320, y: 120 });
+
+  const thinConnector = createConnector('right', 'left');
+  thinConnector.style.arrowSize = 1;
+
+  const thickConnector = createConnector('right', 'left');
+  thickConnector.style.strokeWidth = 8;
+  thickConnector.style.arrowSize = 1;
+
+  const largeArrowConnector = createConnector('right', 'left');
+  largeArrowConnector.style.arrowSize = 2;
+
+  const thinPath = getConnectorPath(thinConnector, source, target, [source, target]);
+  const thickPath = getConnectorPath(thickConnector, source, target, [source, target]);
+  const largeArrowPath = getConnectorPath(largeArrowConnector, source, target, [source, target]);
+
+  const stubLength = thinPath.points[1].x - thinPath.points[0].x;
+  const thickStubLength = thickPath.points[1].x - thickPath.points[0].x;
+  const largeArrowStubLength = largeArrowPath.points[1].x - largeArrowPath.points[0].x;
+
+  assert.ok(Math.abs(stubLength - thickStubLength) < 1e-6, 'stroke width should not affect stub length');
+  assert.ok(
+    largeArrowStubLength > stubLength,
+    'increasing arrow size should expand stub length to preserve spacing'
+  );
+});
+
 test('manual waypoints stay aligned to endpoints', () => {
   const originalSource = createNode('source', { x: 0, y: 0 });
   const originalTarget = createNode('target', { x: 320, y: 200 });

--- a/src/utils/connector.ts
+++ b/src/utils/connector.ts
@@ -9,7 +9,8 @@ import {
 } from '../types/scene';
 
 const EPSILON = 1e-6;
-const DEFAULT_STUB_LENGTH = 48;
+const MIN_STUB_LENGTH = 36;
+const BASE_ARROW_STUB_LENGTH = 24;
 const MAX_PREVIEW_SNAP = 1e-3;
 export type ConnectorAxis = 'horizontal' | 'vertical' | 'diagonal';
 
@@ -30,8 +31,10 @@ const directionForPort: Record<CardinalConnectorPort, ConnectorDirection> = {
 export const getConnectorPortDirection = (port: CardinalConnectorPort): ConnectorDirection =>
   directionForPort[port];
 
-export const getConnectorStubLength = (connector: ConnectorModel): number =>
-  connector.style.strokeWidth ? Math.max(36, connector.style.strokeWidth * 12) : DEFAULT_STUB_LENGTH;
+export const getConnectorStubLength = (connector: ConnectorModel): number => {
+  const arrowSize = connector.style.arrowSize ?? 1;
+  return Math.max(MIN_STUB_LENGTH, arrowSize * BASE_ARROW_STUB_LENGTH);
+};
 
 const clonePoint = (point: Vec2): Vec2 => ({ x: point.x, y: point.y });
 


### PR DESCRIPTION
## Summary
- decouple connector stub length from stroke width so arrowhead spacing follows the start size control
- render connector markers in user-space units to prevent stroke width from scaling arrowheads
- add regression coverage ensuring arrow size affects stub length while stroke width does not

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d5bcee65c4832dbbdf985438096abc