### PR TITLE
Remove node drag transition lag

### DIFF
--- a/src/styles/canvas.css
+++ b/src/styles/canvas.css
@@ -39,7 +39,8 @@
 }
 
 .diagram-node {
-  transition: transform 0.12s ease;
+  transition: none;
+  /* Disable transform easing so dragged nodes track the pointer precisely. */
 }
 
 .diagram-node__shadow {


### PR DESCRIPTION
## Summary
- disable the transform transition on diagram nodes so their contents track pointer drags precisely

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d5c4cff260832d87d1ac7c81dbb1c8