### PR TITLE
Add end connector arrow controls

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -117,6 +117,7 @@ const PENDING_CONNECTOR_STYLE: ConnectorModel['style'] = {
   strokeWidth: 2,
   dashed: false,
   startArrow: { shape: 'none', fill: 'filled' },
+  endArrow: { shape: 'none', fill: 'filled' },
   arrowSize: 1,
   cornerRadius: 12
 };
@@ -238,7 +239,8 @@ const cloneNodeForClipboard = (node: NodeModel): NodeModel => ({
 
 const cloneConnectorStyle = (style: ConnectorModel['style']): ConnectorModel['style'] => ({
   ...style,
-  startArrow: style.startArrow ? { ...style.startArrow } : undefined
+  startArrow: style.startArrow ? { ...style.startArrow } : undefined,
+  endArrow: style.endArrow ? { ...style.endArrow } : undefined
 });
 
 const cloneConnectorForClipboard = (connector: ConnectorModel): ConnectorModel => ({
@@ -3132,14 +3134,14 @@ const CanvasComponent = (
               source: movingEndpoint,
               target: fixedEndpoint,
               points: [],
-              style: { ...connector.style }
+              style: cloneConnectorStyle(connector.style)
             }
           : {
               ...connector,
               source: fixedEndpoint,
               target: movingEndpoint,
               points: [],
-              style: { ...connector.style }
+              style: cloneConnectorStyle(connector.style)
             };
 
       return createPreview(previewConnector);
@@ -3155,7 +3157,7 @@ const CanvasComponent = (
       source: cloneConnectorEndpoint(pendingConnection.source),
       target: targetEndpoint,
       points: [],
-      style: { ...PENDING_CONNECTOR_STYLE }
+      style: cloneConnectorStyle(PENDING_CONNECTOR_STYLE)
     };
 
     return createPreview(previewConnector);

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -119,6 +119,8 @@ const PENDING_CONNECTOR_STYLE: ConnectorModel['style'] = {
   startArrow: { shape: 'none', fill: 'filled' },
   endArrow: { shape: 'none', fill: 'filled' },
   arrowSize: 1,
+  startArrowSize: 1,
+  endArrowSize: 1,
   cornerRadius: 12
 };
 

--- a/src/components/ConnectorToolbar.tsx
+++ b/src/components/ConnectorToolbar.tsx
@@ -31,9 +31,27 @@ const fillOptions = [
   { value: 'outlined', label: 'Outlined' }
 ] as const;
 
-const getLockedFillForShape = (
-  shape: ConnectorModel['style']['startArrow']['shape']
-): ConnectorModel['style']['startArrow']['fill'] | null => {
+type StartArrowConfig = NonNullable<ConnectorModel['style']['startArrow']>;
+type EndArrowConfig = NonNullable<ConnectorModel['style']['endArrow']>;
+
+const createDefaultStartArrow = (): StartArrowConfig => ({ shape: 'none', fill: 'filled' });
+const createDefaultEndArrow = (): EndArrowConfig => ({ shape: 'none', fill: 'filled' });
+
+const getLockedFillForStartShape = (
+  shape: StartArrowConfig['shape']
+): StartArrowConfig['fill'] | null => {
+  if (shape === 'line-arrow') {
+    return 'outlined';
+  }
+  if (shape === 'arrow') {
+    return 'filled';
+  }
+  return null;
+};
+
+const getLockedFillForEndShape = (
+  shape: EndArrowConfig['shape']
+): EndArrowConfig['fill'] | null => {
   if (shape === 'line-arrow') {
     return 'outlined';
   }
@@ -124,9 +142,14 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
   }
 
   const startShape = connector.style.startArrow?.shape ?? 'none';
-  const startLockedFill = getLockedFillForShape(startShape);
+  const startLockedFill = getLockedFillForStartShape(startShape);
   const startFillDisabled = startLockedFill !== null;
   const startFillValue = startLockedFill ?? connector.style.startArrow?.fill ?? 'filled';
+
+  const endShape = connector.style.endArrow?.shape ?? 'none';
+  const endLockedFill = getLockedFillForEndShape(endShape);
+  const endFillDisabled = endLockedFill !== null;
+  const endFillValue = endLockedFill ?? connector.style.endArrow?.fill ?? 'filled';
 
   const handleStrokeWidthChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = Number(event.target.value);
@@ -149,20 +172,42 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
 
   const handleStartArrowShapeChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     const shape = event.target.value as ConnectorModel['style']['startArrow']['shape'];
-    const current = connector.style.startArrow ?? { shape: 'none', fill: 'filled' };
-    const lockedFill = getLockedFillForShape(shape);
+    const current = connector.style.startArrow ?? createDefaultStartArrow();
+    const lockedFill = getLockedFillForStartShape(shape);
     const nextFill = lockedFill ?? current.fill ?? 'filled';
     handleStartArrowChange({ ...current, shape, fill: nextFill });
   };
 
   const handleStartArrowFillChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     const currentShape = connector.style.startArrow?.shape;
-    if (currentShape && getLockedFillForShape(currentShape)) {
+    if (currentShape && getLockedFillForStartShape(currentShape)) {
       return;
     }
     const fill = event.target.value as ConnectorModel['style']['startArrow']['fill'];
-    const current = connector.style.startArrow ?? { shape: 'none', fill: 'filled' };
+    const current = connector.style.startArrow ?? createDefaultStartArrow();
     handleStartArrowChange({ ...current, fill });
+  };
+
+  const handleEndArrowChange = (shape: ConnectorModel['style']['endArrow']) => {
+    onStyleChange({ endArrow: shape });
+  };
+
+  const handleEndArrowShapeChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const shape = event.target.value as ConnectorModel['style']['endArrow']['shape'];
+    const current = connector.style.endArrow ?? createDefaultEndArrow();
+    const lockedFill = getLockedFillForEndShape(shape);
+    const nextFill = lockedFill ?? current.fill ?? 'filled';
+    handleEndArrowChange({ ...current, shape, fill: nextFill });
+  };
+
+  const handleEndArrowFillChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const currentShape = connector.style.endArrow?.shape;
+    if (currentShape && getLockedFillForEndShape(currentShape)) {
+      return;
+    }
+    const fill = event.target.value as ConnectorModel['style']['endArrow']['fill'];
+    const current = connector.style.endArrow ?? createDefaultEndArrow();
+    handleEndArrowChange({ ...current, fill });
   };
 
   const handleArrowSizeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -268,6 +313,46 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
                 value={startFillValue}
                 onChange={handleStartArrowFillChange}
                 disabled={startFillDisabled}
+              >
+                {fillOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+        </section>
+        <section className="connector-toolbar__panel connector-toolbar__panel--end">
+          <h3 className="connector-toolbar__panel-title">End</h3>
+          <div className="connector-toolbar__section">
+            <label className="connector-toolbar__field connector-toolbar__field--block">
+              <span>Size</span>
+              <input
+                type="range"
+                min={0.5}
+                max={4}
+                step={0.1}
+                value={connector.style.arrowSize ?? 1}
+                onChange={handleArrowSizeChange}
+              />
+            </label>
+            <label className="connector-toolbar__field">
+              <span>Shape</span>
+              <select value={endShape} onChange={handleEndArrowShapeChange}>
+                {arrowOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="connector-toolbar__field">
+              <span>Fill</span>
+              <select
+                value={endFillValue}
+                onChange={handleEndArrowFillChange}
+                disabled={endFillDisabled}
               >
                 {fillOptions.map((option) => (
                   <option key={option.value} value={option.value}>

--- a/src/components/ConnectorToolbar.tsx
+++ b/src/components/ConnectorToolbar.tsx
@@ -145,11 +145,13 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
   const startLockedFill = getLockedFillForStartShape(startShape);
   const startFillDisabled = startLockedFill !== null;
   const startFillValue = startLockedFill ?? connector.style.startArrow?.fill ?? 'filled';
+  const startArrowSize = connector.style.startArrowSize ?? connector.style.arrowSize ?? 1;
 
   const endShape = connector.style.endArrow?.shape ?? 'none';
   const endLockedFill = getLockedFillForEndShape(endShape);
   const endFillDisabled = endLockedFill !== null;
   const endFillValue = endLockedFill ?? connector.style.endArrow?.fill ?? 'filled';
+  const endArrowSize = connector.style.endArrowSize ?? connector.style.arrowSize ?? 1;
 
   const handleStrokeWidthChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = Number(event.target.value);
@@ -210,10 +212,19 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
     handleEndArrowChange({ ...current, fill });
   };
 
-  const handleArrowSizeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleStartArrowSizeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = Number(event.target.value);
     if (Number.isFinite(value)) {
-      onStyleChange({ arrowSize: Math.max(0.5, Math.min(4, value)) });
+      const clamped = Math.max(0.5, Math.min(4, value));
+      onStyleChange({ startArrowSize: clamped });
+    }
+  };
+
+  const handleEndArrowSizeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = Number(event.target.value);
+    if (Number.isFinite(value)) {
+      const clamped = Math.max(0.5, Math.min(4, value));
+      onStyleChange({ endArrowSize: clamped });
     }
   };
 
@@ -293,8 +304,8 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
                 min={0.5}
                 max={4}
                 step={0.1}
-                value={connector.style.arrowSize ?? 1}
-                onChange={handleArrowSizeChange}
+                value={startArrowSize}
+                onChange={handleStartArrowSizeChange}
               />
             </label>
             <label className="connector-toolbar__field">
@@ -333,8 +344,8 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
                 min={0.5}
                 max={4}
                 step={0.1}
-                value={connector.style.arrowSize ?? 1}
-                onChange={handleArrowSizeChange}
+                value={endArrowSize}
+                onChange={handleEndArrowSizeChange}
               />
             </label>
             <label className="connector-toolbar__field">

--- a/src/components/DiagramConnector.tsx
+++ b/src/components/DiagramConnector.tsx
@@ -287,8 +287,16 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
 
   const arrowStroke = connector.style.stroke;
   const endpointColor = connector.style.stroke;
-  const arrowSize = Math.max(0.6, connector.style.arrowSize ?? 1);
-  const markerSize = 24 * arrowSize;
+  const startArrowSize = Math.max(
+    0.6,
+    connector.style.startArrowSize ?? connector.style.arrowSize ?? 1
+  );
+  const endArrowSize = Math.max(
+    0.6,
+    connector.style.endArrowSize ?? connector.style.arrowSize ?? 1
+  );
+  const startMarkerSize = 24 * startArrowSize;
+  const endMarkerSize = 24 * endArrowSize;
   const startMarkerId = useMemo(() => `connector-${connector.id}-start`, [connector.id]);
   const endMarkerId = useMemo(() => `connector-${connector.id}-end`, [connector.id]);
 
@@ -304,7 +312,8 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
     markerId: string,
     shape: ArrowShape,
     fill: 'filled' | 'outlined',
-    orientation: 'start' | 'end'
+    orientation: 'start' | 'end',
+    markerSize: number
   ) => {
     if (shape === 'none') {
       return null;
@@ -351,8 +360,14 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
     );
   };
 
-  const startMarker = createMarker(startMarkerId, startArrowShape, startArrowFill, 'start');
-  const endMarker = createMarker(endMarkerId, endArrowShape, endArrowFill, 'end');
+  const startMarker = createMarker(
+    startMarkerId,
+    startArrowShape,
+    startArrowFill,
+    'start',
+    startMarkerSize
+  );
+  const endMarker = createMarker(endMarkerId, endArrowShape, endArrowFill, 'end', endMarkerSize);
 
   const handleLabelInput = (event: React.FormEvent<HTMLDivElement>) => {
     setDraft(event.currentTarget.textContent ?? '');

--- a/src/components/DiagramConnector.tsx
+++ b/src/components/DiagramConnector.tsx
@@ -290,10 +290,15 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
   const arrowSize = Math.max(0.6, connector.style.arrowSize ?? 1);
   const markerSize = 24 * arrowSize;
   const startMarkerId = useMemo(() => `connector-${connector.id}-start`, [connector.id]);
+  const endMarkerId = useMemo(() => `connector-${connector.id}-end`, [connector.id]);
 
   const startArrowShape = connector.style.startArrow?.shape ?? 'none';
   const startArrowFill =
     startArrowShape === 'line-arrow' ? 'outlined' : connector.style.startArrow?.fill ?? 'filled';
+
+  const endArrowShape = connector.style.endArrow?.shape ?? 'none';
+  const endArrowFill =
+    endArrowShape === 'line-arrow' ? 'outlined' : connector.style.endArrow?.fill ?? 'filled';
 
   const createMarker = (
     markerId: string,
@@ -347,6 +352,7 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
   };
 
   const startMarker = createMarker(startMarkerId, startArrowShape, startArrowFill, 'start');
+  const endMarker = createMarker(endMarkerId, endArrowShape, endArrowFill, 'end');
 
   const handleLabelInput = (event: React.FormEvent<HTMLDivElement>) => {
     setDraft(event.currentTarget.textContent ?? '');
@@ -460,6 +466,7 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
   const labelBackground = connector.labelStyle?.background ?? 'rgba(15,23,42,0.85)';
 
   const markerStartUrl = startArrowShape !== 'none' ? `url(#${startMarkerId})` : undefined;
+  const markerEndUrl = endArrowShape !== 'none' ? `url(#${endMarkerId})` : undefined;
 
   const trimmedLabel = connector.label?.trim() ?? '';
   const hasLabel = Boolean(trimmedLabel) || labelEditing;
@@ -491,7 +498,10 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
         ['--connector-width' as string]: `${connector.style.strokeWidth}`
       } as React.CSSProperties}
     >
-      <defs>{startMarker}</defs>
+      <defs>
+        {startMarker}
+        {endMarker}
+      </defs>
       <path className="diagram-connector__hit" d={hitPathData} strokeWidth={28} onPointerDown={onPointerDown} />
       {segments.map((segment) => {
         const isHovered = hoveredSegment === segment.index;
@@ -544,6 +554,7 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
         strokeWidth={connector.style.strokeWidth}
         strokeDasharray={connector.style.dashed ? '12 8' : undefined}
         markerStart={markerStartUrl}
+        markerEnd={markerEndUrl}
         onPointerDown={onPointerDown}
       />
       {selected && (

--- a/src/state/sceneStore.ts
+++ b/src/state/sceneStore.ts
@@ -109,14 +109,15 @@ interface SceneStoreActions {
 
 export type SceneStore = SceneStoreState & SceneStoreActions;
 
-const defaultConnectorStyle: ConnectorModel['style'] = {
+const createDefaultConnectorStyle = (): ConnectorModel['style'] => ({
   stroke: '#e5e7eb',
   strokeWidth: 2,
   dashed: false,
   startArrow: { shape: 'none', fill: 'filled' },
+  endArrow: { shape: 'none', fill: 'filled' },
   arrowSize: 1,
   cornerRadius: 12
-};
+});
 
 const defaultConnectorLabelStyle: ConnectorLabelStyle = {
   fontSize: 14,
@@ -136,7 +137,7 @@ const createInitialScene = (): SceneContent => {
       id: nanoid(),
       source: { nodeId: start.id, port: 'right' },
       target: { nodeId: collect.id, port: 'left' },
-      style: { ...defaultConnectorStyle },
+      style: createDefaultConnectorStyle(),
       label: 'Begin',
       labelPosition: 0.5,
       labelOffset: 18,
@@ -146,7 +147,7 @@ const createInitialScene = (): SceneContent => {
       id: nanoid(),
       source: { nodeId: collect.id, port: 'right' },
       target: { nodeId: decision.id, port: 'left' },
-      style: { ...defaultConnectorStyle },
+      style: createDefaultConnectorStyle(),
       labelPosition: 0.5,
       labelOffset: 18,
       labelStyle: { ...defaultConnectorLabelStyle }
@@ -155,7 +156,7 @@ const createInitialScene = (): SceneContent => {
       id: nanoid(),
       source: { nodeId: decision.id, port: 'right' },
       target: { nodeId: done.id, port: 'left' },
-      style: { ...defaultConnectorStyle },
+      style: createDefaultConnectorStyle(),
       label: 'Yes',
       labelPosition: 0.5,
       labelOffset: 18,
@@ -247,7 +248,8 @@ export const useSceneStore = create<SceneStore>((set, get) => ({
           target: cloneConnectorEndpoint(connector.target),
           style: {
             ...connector.style,
-            startArrow: connector.style.startArrow ? { ...connector.style.startArrow } : undefined
+            startArrow: connector.style.startArrow ? { ...connector.style.startArrow } : undefined,
+            endArrow: connector.style.endArrow ? { ...connector.style.endArrow } : undefined
           },
           labelStyle: connector.labelStyle ? { ...connector.labelStyle } : undefined,
           points: connector.points?.map((point) => ({ ...point }))
@@ -470,7 +472,7 @@ export const useSceneStore = create<SceneStore>((set, get) => ({
         id: nanoid(),
         source,
         target,
-        style: { ...defaultConnectorStyle },
+        style: createDefaultConnectorStyle(),
         labelPosition: 0.5,
         labelOffset: 18,
         labelStyle: { ...defaultConnectorLabelStyle }
@@ -507,7 +509,11 @@ export const useSceneStore = create<SceneStore>((set, get) => ({
         ...existing,
         source: cloneConnectorEndpoint(existing.source),
         target: cloneConnectorEndpoint(existing.target),
-        style: { ...existing.style },
+        style: {
+          ...existing.style,
+          startArrow: existing.style.startArrow ? { ...existing.style.startArrow } : undefined,
+          endArrow: existing.style.endArrow ? { ...existing.style.endArrow } : undefined
+        },
         labelStyle: existing.labelStyle ? { ...existing.labelStyle } : undefined,
         points: existing.points?.map((point) => ({ ...point }))
       };
@@ -515,7 +521,16 @@ export const useSceneStore = create<SceneStore>((set, get) => ({
       const { style, points, labelStyle, source, target, ...rest } = patch;
 
       if (style) {
-        nextConnector.style = { ...nextConnector.style, ...style };
+        const nextStyle: ConnectorModel['style'] = { ...nextConnector.style, ...style };
+        if ('startArrow' in style) {
+          nextStyle.startArrow = style.startArrow
+            ? { ...style.startArrow }
+            : style.startArrow;
+        }
+        if ('endArrow' in style) {
+          nextStyle.endArrow = style.endArrow ? { ...style.endArrow } : style.endArrow;
+        }
+        nextConnector.style = nextStyle;
       }
       if (labelStyle !== undefined) {
         nextConnector.labelStyle = labelStyle ? { ...labelStyle } : undefined;

--- a/src/state/sceneStore.ts
+++ b/src/state/sceneStore.ts
@@ -116,6 +116,8 @@ const createDefaultConnectorStyle = (): ConnectorModel['style'] => ({
   startArrow: { shape: 'none', fill: 'filled' },
   endArrow: { shape: 'none', fill: 'filled' },
   arrowSize: 1,
+  startArrowSize: 1,
+  endArrowSize: 1,
   cornerRadius: 12
 });
 

--- a/src/types/scene.ts
+++ b/src/types/scene.ts
@@ -93,6 +93,7 @@ export interface ConnectorStyle {
   strokeWidth: number;
   dashed?: boolean;
   startArrow?: ConnectorArrowStyle;
+  endArrow?: ConnectorArrowStyle;
   arrowSize?: number;
   cornerRadius?: number;
 }

--- a/src/types/scene.ts
+++ b/src/types/scene.ts
@@ -95,6 +95,8 @@ export interface ConnectorStyle {
   startArrow?: ConnectorArrowStyle;
   endArrow?: ConnectorArrowStyle;
   arrowSize?: number;
+  startArrowSize?: number;
+  endArrowSize?: number;
   cornerRadius?: number;
 }
 

--- a/src/utils/__tests__/connector.test.ts
+++ b/src/utils/__tests__/connector.test.ts
@@ -40,6 +40,7 @@ const defaultConnectorStyle: Mutable<ConnectorModel['style']> = {
   strokeWidth: 2,
   dashed: false,
   startArrow: { shape: 'none', fill: 'filled' },
+  endArrow: { shape: 'none', fill: 'filled' },
   arrowSize: 1,
   cornerRadius: 12
 };

--- a/src/utils/scene.ts
+++ b/src/utils/scene.ts
@@ -175,6 +175,12 @@ export const cloneScene = (scene: SceneContent): SceneContent => ({
     ...connector,
     source: cloneConnectorEndpoint(connector.source),
     target: cloneConnectorEndpoint(connector.target),
+    style: {
+      ...connector.style,
+      startArrow: connector.style.startArrow ? { ...connector.style.startArrow } : undefined,
+      endArrow: connector.style.endArrow ? { ...connector.style.endArrow } : undefined
+    },
+    labelStyle: connector.labelStyle ? { ...connector.labelStyle } : undefined,
     points: connector.points?.map((point) => ({ ...point }))
   }))
 });


### PR DESCRIPTION
## Summary
- add end-arrow styling to connector models and default factories
- expose end arrow controls in the connector toolbar and render matching SVG markers
- clone connector styles safely to keep start and end arrow calculations independent

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d5fd878108832db629d58623f480a1