### PR TITLE
Add configurable end connector markers

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -117,6 +117,7 @@ const PENDING_CONNECTOR_STYLE: ConnectorModel['style'] = {
   strokeWidth: 2,
   dashed: false,
   startArrow: { shape: 'none', fill: 'filled' },
+  endArrow: { shape: 'none', fill: 'filled' },
   arrowSize: 1,
   cornerRadius: 12
 };
@@ -238,7 +239,8 @@ const cloneNodeForClipboard = (node: NodeModel): NodeModel => ({
 
 const cloneConnectorStyle = (style: ConnectorModel['style']): ConnectorModel['style'] => ({
   ...style,
-  startArrow: style.startArrow ? { ...style.startArrow } : undefined
+  startArrow: style.startArrow ? { ...style.startArrow } : undefined,
+  endArrow: style.endArrow ? { ...style.endArrow } : undefined
 });
 
 const cloneConnectorForClipboard = (connector: ConnectorModel): ConnectorModel => ({

--- a/src/components/ConnectorToolbar.tsx
+++ b/src/components/ConnectorToolbar.tsx
@@ -128,6 +128,11 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
   const startFillDisabled = startLockedFill !== null;
   const startFillValue = startLockedFill ?? connector.style.startArrow?.fill ?? 'filled';
 
+  const endShape = connector.style.endArrow?.shape ?? 'none';
+  const endLockedFill = getLockedFillForShape(endShape);
+  const endFillDisabled = endLockedFill !== null;
+  const endFillValue = endLockedFill ?? connector.style.endArrow?.fill ?? 'filled';
+
   const handleStrokeWidthChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = Number(event.target.value);
     if (Number.isFinite(value)) {
@@ -163,6 +168,28 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
     const fill = event.target.value as ConnectorModel['style']['startArrow']['fill'];
     const current = connector.style.startArrow ?? { shape: 'none', fill: 'filled' };
     handleStartArrowChange({ ...current, fill });
+  };
+
+  const handleEndArrowChange = (shape: ConnectorModel['style']['startArrow']) => {
+    onStyleChange({ endArrow: shape });
+  };
+
+  const handleEndArrowShapeChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const shape = event.target.value as ConnectorModel['style']['startArrow']['shape'];
+    const current = connector.style.endArrow ?? { shape: 'none', fill: 'filled' };
+    const lockedFill = getLockedFillForShape(shape);
+    const nextFill = lockedFill ?? current.fill ?? 'filled';
+    handleEndArrowChange({ ...current, shape, fill: nextFill });
+  };
+
+  const handleEndArrowFillChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const currentShape = connector.style.endArrow?.shape;
+    if (currentShape && getLockedFillForShape(currentShape)) {
+      return;
+    }
+    const fill = event.target.value as ConnectorModel['style']['startArrow']['fill'];
+    const current = connector.style.endArrow ?? { shape: 'none', fill: 'filled' };
+    handleEndArrowChange({ ...current, fill });
   };
 
   const handleArrowSizeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -268,6 +295,35 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
                 value={startFillValue}
                 onChange={handleStartArrowFillChange}
                 disabled={startFillDisabled}
+              >
+                {fillOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+        </section>
+        <section className="connector-toolbar__panel connector-toolbar__panel--end">
+          <h3 className="connector-toolbar__panel-title">End</h3>
+          <div className="connector-toolbar__section">
+            <label className="connector-toolbar__field">
+              <span>Shape</span>
+              <select value={endShape} onChange={handleEndArrowShapeChange}>
+                {arrowOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="connector-toolbar__field">
+              <span>Fill</span>
+              <select
+                value={endFillValue}
+                onChange={handleEndArrowFillChange}
+                disabled={endFillDisabled}
               >
                 {fillOptions.map((option) => (
                   <option key={option.value} value={option.value}>

--- a/src/components/DiagramConnector.tsx
+++ b/src/components/DiagramConnector.tsx
@@ -290,10 +290,15 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
   const arrowSize = Math.max(0.6, connector.style.arrowSize ?? 1);
   const markerSize = 24 * arrowSize;
   const startMarkerId = useMemo(() => `connector-${connector.id}-start`, [connector.id]);
+  const endMarkerId = useMemo(() => `connector-${connector.id}-end`, [connector.id]);
 
   const startArrowShape = connector.style.startArrow?.shape ?? 'none';
   const startArrowFill =
     startArrowShape === 'line-arrow' ? 'outlined' : connector.style.startArrow?.fill ?? 'filled';
+
+  const endArrowShape = connector.style.endArrow?.shape ?? 'none';
+  const endArrowFill =
+    endArrowShape === 'line-arrow' ? 'outlined' : connector.style.endArrow?.fill ?? 'filled';
 
   const createMarker = (
     markerId: string,
@@ -347,6 +352,9 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
   };
 
   const startMarker = createMarker(startMarkerId, startArrowShape, startArrowFill, 'start');
+  // Use the "start" orientation for end markers so they continue in the
+  // connector's travel direction (pointing away from the line).
+  const endMarker = createMarker(endMarkerId, endArrowShape, endArrowFill, 'start');
 
   const handleLabelInput = (event: React.FormEvent<HTMLDivElement>) => {
     setDraft(event.currentTarget.textContent ?? '');
@@ -460,6 +468,7 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
   const labelBackground = connector.labelStyle?.background ?? 'rgba(15,23,42,0.85)';
 
   const markerStartUrl = startArrowShape !== 'none' ? `url(#${startMarkerId})` : undefined;
+  const markerEndUrl = endArrowShape !== 'none' ? `url(#${endMarkerId})` : undefined;
 
   const trimmedLabel = connector.label?.trim() ?? '';
   const hasLabel = Boolean(trimmedLabel) || labelEditing;
@@ -491,7 +500,10 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
         ['--connector-width' as string]: `${connector.style.strokeWidth}`
       } as React.CSSProperties}
     >
-      <defs>{startMarker}</defs>
+      <defs>
+        {startMarker}
+        {endMarker}
+      </defs>
       <path className="diagram-connector__hit" d={hitPathData} strokeWidth={28} onPointerDown={onPointerDown} />
       {segments.map((segment) => {
         const isHovered = hoveredSegment === segment.index;
@@ -544,6 +556,7 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
         strokeWidth={connector.style.strokeWidth}
         strokeDasharray={connector.style.dashed ? '12 8' : undefined}
         markerStart={markerStartUrl}
+        markerEnd={markerEndUrl}
         onPointerDown={onPointerDown}
       />
       {selected && (

--- a/src/components/DiagramConnector.tsx
+++ b/src/components/DiagramConnector.tsx
@@ -354,7 +354,8 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
   const startMarker = createMarker(startMarkerId, startArrowShape, startArrowFill, 'start');
   // Use the "start" orientation for end markers so they continue in the
   // connector's travel direction (pointing away from the line).
-  const endMarker = createMarker(endMarkerId, endArrowShape, endArrowFill, 'start');
+  //end fix?
+  const endMarker = createMarker(endMarkerId, endArrowShape, endArrowFill, 'end');
 
   const handleLabelInput = (event: React.FormEvent<HTMLDivElement>) => {
     setDraft(event.currentTarget.textContent ?? '');

--- a/src/state/sceneStore.ts
+++ b/src/state/sceneStore.ts
@@ -114,6 +114,7 @@ const defaultConnectorStyle: ConnectorModel['style'] = {
   strokeWidth: 2,
   dashed: false,
   startArrow: { shape: 'none', fill: 'filled' },
+  endArrow: { shape: 'none', fill: 'filled' },
   arrowSize: 1,
   cornerRadius: 12
 };
@@ -247,7 +248,8 @@ export const useSceneStore = create<SceneStore>((set, get) => ({
           target: cloneConnectorEndpoint(connector.target),
           style: {
             ...connector.style,
-            startArrow: connector.style.startArrow ? { ...connector.style.startArrow } : undefined
+            startArrow: connector.style.startArrow ? { ...connector.style.startArrow } : undefined,
+            endArrow: connector.style.endArrow ? { ...connector.style.endArrow } : undefined
           },
           labelStyle: connector.labelStyle ? { ...connector.labelStyle } : undefined,
           points: connector.points?.map((point) => ({ ...point }))

--- a/src/types/scene.ts
+++ b/src/types/scene.ts
@@ -93,6 +93,7 @@ export interface ConnectorStyle {
   strokeWidth: number;
   dashed?: boolean;
   startArrow?: ConnectorArrowStyle;
+  endArrow?: ConnectorArrowStyle;
   arrowSize?: number;
   cornerRadius?: number;
 }

--- a/src/utils/__tests__/connector.test.ts
+++ b/src/utils/__tests__/connector.test.ts
@@ -40,6 +40,7 @@ const defaultConnectorStyle: Mutable<ConnectorModel['style']> = {
   strokeWidth: 2,
   dashed: false,
   startArrow: { shape: 'none', fill: 'filled' },
+  endArrow: { shape: 'none', fill: 'filled' },
   arrowSize: 1,
   cornerRadius: 12
 };


### PR DESCRIPTION
## Summary
- allow connectors to configure end markers that mirror the start marker controls
- render end markers so they always point away from the connector line and persist through scene operations
- update connector defaults, cloning helpers, and tests for the new end marker data

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d731af6d54832d97b4a565849af5cd