### PR TITLE
Add stop connector controls

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -117,6 +117,7 @@ const PENDING_CONNECTOR_STYLE: ConnectorModel['style'] = {
   strokeWidth: 2,
   dashed: false,
   startArrow: { shape: 'none', fill: 'filled' },
+  stopArrow: { shape: 'none', fill: 'filled' },
   arrowSize: 1,
   cornerRadius: 12
 };
@@ -238,7 +239,8 @@ const cloneNodeForClipboard = (node: NodeModel): NodeModel => ({
 
 const cloneConnectorStyle = (style: ConnectorModel['style']): ConnectorModel['style'] => ({
   ...style,
-  startArrow: style.startArrow ? { ...style.startArrow } : undefined
+  startArrow: style.startArrow ? { ...style.startArrow } : undefined,
+  stopArrow: style.stopArrow ? { ...style.stopArrow } : undefined
 });
 
 const cloneConnectorForClipboard = (connector: ConnectorModel): ConnectorModel => ({

--- a/src/components/ConnectorToolbar.tsx
+++ b/src/components/ConnectorToolbar.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useRef } from 'react';
-import { ConnectorModel } from '../types/scene';
+import { ConnectorArrowStyle, ConnectorModel } from '../types/scene';
 import { FloatingMenuChrome } from './FloatingMenuChrome';
 import { useFloatingMenuDrag } from '../hooks/useFloatingMenuDrag';
 import { computeFloatingMenuPlacement } from '../utils/floatingMenu';
@@ -32,8 +32,8 @@ const fillOptions = [
 ] as const;
 
 const getLockedFillForShape = (
-  shape: ConnectorModel['style']['startArrow']['shape']
-): ConnectorModel['style']['startArrow']['fill'] | null => {
+  shape: ConnectorArrowStyle['shape']
+): ConnectorArrowStyle['fill'] | null => {
   if (shape === 'line-arrow') {
     return 'outlined';
   }
@@ -128,6 +128,11 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
   const startFillDisabled = startLockedFill !== null;
   const startFillValue = startLockedFill ?? connector.style.startArrow?.fill ?? 'filled';
 
+  const stopShape = connector.style.stopArrow?.shape ?? 'none';
+  const stopLockedFill = getLockedFillForShape(stopShape);
+  const stopFillDisabled = stopLockedFill !== null;
+  const stopFillValue = stopLockedFill ?? connector.style.stopArrow?.fill ?? 'filled';
+
   const handleStrokeWidthChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = Number(event.target.value);
     if (Number.isFinite(value)) {
@@ -170,6 +175,28 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
     if (Number.isFinite(value)) {
       onStyleChange({ arrowSize: Math.max(0.5, Math.min(4, value)) });
     }
+  };
+
+  const handleStopArrowChange = (shape: ConnectorModel['style']['stopArrow']) => {
+    onStyleChange({ stopArrow: shape });
+  };
+
+  const handleStopArrowShapeChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const shape = event.target.value as ConnectorModel['style']['stopArrow']['shape'];
+    const current = connector.style.stopArrow ?? { shape: 'none', fill: 'filled' };
+    const lockedFill = getLockedFillForShape(shape);
+    const nextFill = lockedFill ?? current.fill ?? 'filled';
+    handleStopArrowChange({ ...current, shape, fill: nextFill });
+  };
+
+  const handleStopArrowFillChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const currentShape = connector.style.stopArrow?.shape;
+    if (currentShape && getLockedFillForShape(currentShape)) {
+      return;
+    }
+    const fill = event.target.value as ConnectorModel['style']['stopArrow']['fill'];
+    const current = connector.style.stopArrow ?? { shape: 'none', fill: 'filled' };
+    handleStopArrowChange({ ...current, fill });
   };
 
   const handleCornerRadiusChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -268,6 +295,46 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
                 value={startFillValue}
                 onChange={handleStartArrowFillChange}
                 disabled={startFillDisabled}
+              >
+                {fillOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+        </section>
+        <section className="connector-toolbar__panel connector-toolbar__panel--stop">
+          <h3 className="connector-toolbar__panel-title">Stop</h3>
+          <div className="connector-toolbar__section">
+            <label className="connector-toolbar__field connector-toolbar__field--block">
+              <span>Size</span>
+              <input
+                type="range"
+                min={0.5}
+                max={4}
+                step={0.1}
+                value={connector.style.arrowSize ?? 1}
+                onChange={handleArrowSizeChange}
+              />
+            </label>
+            <label className="connector-toolbar__field">
+              <span>Shape</span>
+              <select value={stopShape} onChange={handleStopArrowShapeChange}>
+                {arrowOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="connector-toolbar__field">
+              <span>Fill</span>
+              <select
+                value={stopFillValue}
+                onChange={handleStopArrowFillChange}
+                disabled={stopFillDisabled}
               >
                 {fillOptions.map((option) => (
                   <option key={option.value} value={option.value}>

--- a/src/components/DiagramConnector.tsx
+++ b/src/components/DiagramConnector.tsx
@@ -290,10 +290,14 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
   const arrowSize = Math.max(0.6, connector.style.arrowSize ?? 1);
   const markerSize = 24 * arrowSize;
   const startMarkerId = useMemo(() => `connector-${connector.id}-start`, [connector.id]);
+  const endMarkerId = useMemo(() => `connector-${connector.id}-end`, [connector.id]);
 
   const startArrowShape = connector.style.startArrow?.shape ?? 'none';
   const startArrowFill =
     startArrowShape === 'line-arrow' ? 'outlined' : connector.style.startArrow?.fill ?? 'filled';
+  const endArrowShape = connector.style.stopArrow?.shape ?? 'none';
+  const endArrowFill =
+    endArrowShape === 'line-arrow' ? 'outlined' : connector.style.stopArrow?.fill ?? 'filled';
 
   const createMarker = (
     markerId: string,
@@ -347,6 +351,7 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
   };
 
   const startMarker = createMarker(startMarkerId, startArrowShape, startArrowFill, 'start');
+  const endMarker = createMarker(endMarkerId, endArrowShape, endArrowFill, 'end');
 
   const handleLabelInput = (event: React.FormEvent<HTMLDivElement>) => {
     setDraft(event.currentTarget.textContent ?? '');
@@ -460,6 +465,7 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
   const labelBackground = connector.labelStyle?.background ?? 'rgba(15,23,42,0.85)';
 
   const markerStartUrl = startArrowShape !== 'none' ? `url(#${startMarkerId})` : undefined;
+  const markerEndUrl = endArrowShape !== 'none' ? `url(#${endMarkerId})` : undefined;
 
   const trimmedLabel = connector.label?.trim() ?? '';
   const hasLabel = Boolean(trimmedLabel) || labelEditing;
@@ -491,7 +497,10 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
         ['--connector-width' as string]: `${connector.style.strokeWidth}`
       } as React.CSSProperties}
     >
-      <defs>{startMarker}</defs>
+      <defs>
+        {startMarker}
+        {endMarker}
+      </defs>
       <path className="diagram-connector__hit" d={hitPathData} strokeWidth={28} onPointerDown={onPointerDown} />
       {segments.map((segment) => {
         const isHovered = hoveredSegment === segment.index;
@@ -544,6 +553,7 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
         strokeWidth={connector.style.strokeWidth}
         strokeDasharray={connector.style.dashed ? '12 8' : undefined}
         markerStart={markerStartUrl}
+        markerEnd={markerEndUrl}
         onPointerDown={onPointerDown}
       />
       {selected && (

--- a/src/components/DiagramConnector.tsx
+++ b/src/components/DiagramConnector.tsx
@@ -299,12 +299,10 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
       return null;
     }
 
-    const refX =
-      shape === 'circle'
-        ? markerRefXForShape(shape, orientation)
-        : markerRefXForShape(shape, 'end');
+    const refX = markerRefXForShape(shape, orientation);
     const visuals = markerVisualsForShape(shape, fill, arrowStroke);
     const lineCap = shape === 'line-arrow' ? 'round' : 'butt';
+    const orient = orientation === 'start' ? 'auto-start-reverse' : 'auto';
 
     return (
       <marker
@@ -314,7 +312,7 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
         markerHeight={markerSize}
         refX={refX}
         refY={6}
-        orient="auto-start-reverse"
+        orient={orient}
         markerUnits="userSpaceOnUse"
       >
         {shape === 'circle' ? (

--- a/src/components/DiagramConnector.tsx
+++ b/src/components/DiagramConnector.tsx
@@ -45,28 +45,18 @@ const clampLabelOffset = (value: number) =>
 const clampLabelRadius = (value: number) =>
   Math.max(0, Math.min(MAX_LABEL_DISTANCE, Math.abs(value)));
 
-const arrowPathForShape = (shape: ArrowShape, orientation: 'start' | 'end'): string | null => {
+const arrowPathForShape = (shape: ArrowShape): string | null => {
   switch (shape) {
     case 'triangle':
-      return orientation === 'end'
-        ? 'M12 1 L0 6 L12 11 Z'
-        : 'M0 1 L12 6 L0 11 Z';
+      return 'M0 1 L12 6 L0 11 Z';
     case 'triangle-inward':
-      return orientation === 'end'
-        ? 'M12 1 L0 6 L12 11 Z'
-        : 'M12 1 L0 6 L12 11 Z';
+      return 'M12 1 L0 6 L12 11 Z';
     case 'arrow':
-      return orientation === 'end'
-        ? 'M0 1 L12 6 L0 11 Z'
-        : 'M0 1 L12 6 L0 11 Z';
+      return 'M0 1 L12 6 L0 11 Z';
     case 'line-arrow':
-      return orientation === 'end'
-        ? 'M12 1 L0 6 L12 11'
-        : 'M0 1 L12 6 L0 11';
+      return 'M0 1 L12 6 L0 11';
     case 'diamond':
-      return orientation === 'end'
-        ? 'M0 6 L6 0 L12 6 L6 12 Z'
-        : 'M12 6 L6 0 L0 6 L6 12 Z';
+      return 'M12 6 L6 0 L0 6 L6 12 Z';
     case 'circle':
       return 'M6 0 A6 6 0 1 1 5.999 0 Z';
     default:
@@ -338,7 +328,7 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
           />
         ) : (
           <path
-            d={arrowPathForShape(shape, orientation) ?? ''}
+            d={arrowPathForShape(shape) ?? ''}
             fill={visuals.fill}
             stroke={visuals.stroke}
             strokeWidth={visuals.strokeWidth}

--- a/src/state/sceneStore.ts
+++ b/src/state/sceneStore.ts
@@ -115,13 +115,17 @@ const defaultConnectorStyle: ConnectorModel['style'] = {
   strokeWidth: 2,
   dashed: false,
   startArrow: { shape: 'none', fill: 'filled' },
+  stopArrow: { shape: 'none', fill: 'filled' },
   arrowSize: 1,
   cornerRadius: 12
 };
 
-const connectorStyle = (startArrow?: ConnectorArrowStyle): ConnectorModel['style'] => ({
+const connectorStyle = (
+  arrows?: { startArrow?: ConnectorArrowStyle; stopArrow?: ConnectorArrowStyle }
+): ConnectorModel['style'] => ({
   ...defaultConnectorStyle,
-  ...(startArrow ? { startArrow } : {})
+  ...(arrows?.startArrow ? { startArrow: arrows.startArrow } : {}),
+  ...(arrows?.stopArrow ? { stopArrow: arrows.stopArrow } : {})
 });
 
 const defaultConnectorLabelStyle: ConnectorLabelStyle = {
@@ -145,7 +149,7 @@ const createInitialScene = (): SceneContent => {
       id: nanoid(),
       source: { nodeId: start.id, port: 'right' },
       target: { nodeId: collect.id, port: 'left' },
-      style: connectorStyle({ shape: 'triangle', fill: 'filled' }),
+      style: connectorStyle({ startArrow: { shape: 'triangle', fill: 'filled' } }),
       label: 'Begin',
       labelPosition: 0.5,
       labelOffset: 18,
@@ -155,7 +159,7 @@ const createInitialScene = (): SceneContent => {
       id: nanoid(),
       source: { nodeId: collect.id, port: 'right' },
       target: { nodeId: decision.id, port: 'left' },
-      style: connectorStyle({ shape: 'diamond', fill: 'outlined' }),
+      style: connectorStyle({ startArrow: { shape: 'diamond', fill: 'outlined' } }),
       label: 'Forward',
       labelPosition: 0.5,
       labelOffset: 18,
@@ -165,7 +169,7 @@ const createInitialScene = (): SceneContent => {
       id: nanoid(),
       source: { nodeId: decision.id, port: 'right' },
       target: { nodeId: done.id, port: 'left' },
-      style: connectorStyle({ shape: 'circle', fill: 'filled' }),
+      style: connectorStyle({ startArrow: { shape: 'circle', fill: 'filled' } }),
       label: 'Yes',
       labelPosition: 0.5,
       labelOffset: 18,
@@ -185,7 +189,7 @@ const createInitialScene = (): SceneContent => {
       id: nanoid(),
       source: { nodeId: review.id, port: 'left' },
       target: { nodeId: retry.id, port: 'right' },
-      style: connectorStyle({ shape: 'line-arrow', fill: 'outlined' }),
+      style: connectorStyle({ startArrow: { shape: 'line-arrow', fill: 'outlined' } }),
       label: 'Rework',
       labelPosition: 0.5,
       labelOffset: 18,
@@ -205,7 +209,7 @@ const createInitialScene = (): SceneContent => {
       id: nanoid(),
       source: { nodeId: decision.id, port: 'bottom' },
       target: { nodeId: notify.id, port: 'top' },
-      style: connectorStyle({ shape: 'triangle-inward', fill: 'filled' }),
+      style: connectorStyle({ startArrow: { shape: 'triangle-inward', fill: 'filled' } }),
       label: 'No',
       labelPosition: 0.5,
       labelOffset: 18,
@@ -215,7 +219,7 @@ const createInitialScene = (): SceneContent => {
       id: nanoid(),
       source: { nodeId: notify.id, port: 'right' },
       target: { position: { x: 620, y: 220 } },
-      style: connectorStyle({ shape: 'arrow', fill: 'filled' }),
+      style: connectorStyle({ startArrow: { shape: 'arrow', fill: 'filled' } }),
       label: 'Webhook',
       labelPosition: 0.5,
       labelOffset: 18,
@@ -225,7 +229,7 @@ const createInitialScene = (): SceneContent => {
       id: nanoid(),
       source: { nodeId: start.id, port: 'top' },
       target: { position: { x: -380, y: -360 } },
-      style: connectorStyle({ shape: 'triangle', fill: 'outlined' }),
+      style: connectorStyle({ startArrow: { shape: 'triangle', fill: 'outlined' } }),
       label: 'Monitoring',
       labelPosition: 0.5,
       labelOffset: 18,
@@ -317,7 +321,8 @@ export const useSceneStore = create<SceneStore>((set, get) => ({
           target: cloneConnectorEndpoint(connector.target),
           style: {
             ...connector.style,
-            startArrow: connector.style.startArrow ? { ...connector.style.startArrow } : undefined
+            startArrow: connector.style.startArrow ? { ...connector.style.startArrow } : undefined,
+            stopArrow: connector.style.stopArrow ? { ...connector.style.stopArrow } : undefined
           },
           labelStyle: connector.labelStyle ? { ...connector.labelStyle } : undefined,
           points: connector.points?.map((point) => ({ ...point }))

--- a/src/types/scene.ts
+++ b/src/types/scene.ts
@@ -93,6 +93,7 @@ export interface ConnectorStyle {
   strokeWidth: number;
   dashed?: boolean;
   startArrow?: ConnectorArrowStyle;
+  stopArrow?: ConnectorArrowStyle;
   arrowSize?: number;
   cornerRadius?: number;
 }

--- a/src/utils/__tests__/connector.test.ts
+++ b/src/utils/__tests__/connector.test.ts
@@ -40,6 +40,7 @@ const defaultConnectorStyle: Mutable<ConnectorModel['style']> = {
   strokeWidth: 2,
   dashed: false,
   startArrow: { shape: 'none', fill: 'filled' },
+  stopArrow: { shape: 'none', fill: 'filled' },
   arrowSize: 1,
   cornerRadius: 12
 };
@@ -98,6 +99,13 @@ test('connectors create orthogonal paths with outward stubs', () => {
   const firstSegment = { start: path.points[0], end: path.points[1] };
   assert.ok(Math.abs(firstSegment.start.y - firstSegment.end.y) < 1e-3, 'start stub should be horizontal');
   assert.ok(firstSegment.end.x > firstSegment.start.x, 'start stub should extend outward');
+
+  const lastSegment = {
+    start: path.points[path.points.length - 2],
+    end: path.points[path.points.length - 1]
+  };
+  assert.ok(Math.abs(lastSegment.start.y - lastSegment.end.y) < 1e-3, 'stop stub should be horizontal');
+  assert.ok(lastSegment.start.x < lastSegment.end.x, 'stop stub should extend outward');
 
   for (let index = 0; index < path.points.length - 1; index += 1) {
     const a = path.points[index];

--- a/src/utils/scene.ts
+++ b/src/utils/scene.ts
@@ -175,6 +175,11 @@ export const cloneScene = (scene: SceneContent): SceneContent => ({
     ...connector,
     source: cloneConnectorEndpoint(connector.source),
     target: cloneConnectorEndpoint(connector.target),
+    style: {
+      ...connector.style,
+      startArrow: connector.style.startArrow ? { ...connector.style.startArrow } : undefined,
+      stopArrow: connector.style.stopArrow ? { ...connector.style.stopArrow } : undefined
+    },
     points: connector.points?.map((point) => ({ ...point }))
   }))
 });


### PR DESCRIPTION
## Summary
- add stop arrow style support across connector models and scene helpers
- extend the connector toolbar with a Stop panel that mirrors Start controls
- render stop arrow markers and expand connector tests for end stubs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d94162ed28832da8394fbeeae6da73