### PR TITLE
Align triangle connector anchors with triangle edges

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -74,7 +74,7 @@ import {
   translateBounds
 } from '../utils/snap';
 import { DiagramNode } from './DiagramNode';
-import { DiagramConnector } from './DiagramConnector';
+import { DiagramConnector, DiagramConnectorEndpoints } from './DiagramConnector';
 import { SelectionToolbar } from './SelectionToolbar';
 import { ConnectorToolbar } from './ConnectorToolbar';
 import { ConnectorTextToolbar } from './ConnectorTextToolbar';
@@ -3255,6 +3255,7 @@ const CanvasComponent = (
                   ? activeConnectorEdit.previewPoints
                   : undefined
               }
+              renderEndpoints={false}
             />
           ))}
           {nodes.map((node) => (
@@ -3272,6 +3273,28 @@ const CanvasComponent = (
               onDoubleClick={(event) => handleNodeDoubleClick(event, node)}
             />
           ))}
+          {connectors.map((connector) => {
+            if (!selectedConnectorIds.includes(connector.id)) {
+              return null;
+            }
+            return (
+              <DiagramConnectorEndpoints
+                key={`${connector.id}-endpoints`}
+                connector={connector}
+                source={resolveEndpointNode(connector.source)}
+                target={resolveEndpointNode(connector.target)}
+                nodes={nodes}
+                onEndpointPointerDown={(event, endpoint) =>
+                  handleConnectorEndpointPointerDown(event, connector, endpoint)
+                }
+                previewPoints={
+                  activeConnectorEdit?.connectorId === connector.id
+                    ? activeConnectorEdit.previewPoints
+                    : undefined
+                }
+              />
+            );
+          })}
           {pendingPreview && (
             <path
               className="connector-pending"

--- a/src/components/DiagramConnector.tsx
+++ b/src/components/DiagramConnector.tsx
@@ -36,6 +36,10 @@ interface DiagramConnectorProps {
 const DEFAULT_LABEL_POSITION = 0.5;
 const DEFAULT_LABEL_DISTANCE = 18;
 const MAX_LABEL_DISTANCE = 60;
+const ENDPOINT_HANDLE_OFFSET = 14;
+const ENDPOINT_HANDLE_EPSILON = 1e-6;
+const ENDPOINT_VISUAL_RADIUS = 6.5;
+const ENDPOINT_HIT_RADIUS = 20;
 
 const clampLabel = (value: string) => value.trim();
 
@@ -44,6 +48,35 @@ const clampLabelOffset = (value: number) =>
 
 const clampLabelRadius = (value: number) =>
   Math.max(0, Math.min(MAX_LABEL_DISTANCE, Math.abs(value)));
+
+const computeEndpointHandleCenter = (points: Vec2[], which: 'start' | 'end'): Vec2 => {
+  const anchorIndex = which === 'start' ? 0 : points.length - 1;
+  const neighborIndex = which === 'start' ? 1 : points.length - 2;
+  const anchor = points[anchorIndex];
+  const neighbor = points[neighborIndex];
+
+  if (!anchor) {
+    return { x: 0, y: 0 };
+  }
+
+  if (!neighbor) {
+    return { x: anchor.x, y: anchor.y };
+  }
+
+  const delta = { x: neighbor.x - anchor.x, y: neighbor.y - anchor.y };
+  const length = Math.hypot(delta.x, delta.y);
+
+  if (length <= ENDPOINT_HANDLE_EPSILON) {
+    return { x: anchor.x, y: anchor.y };
+  }
+
+  const scale = ENDPOINT_HANDLE_OFFSET / length;
+
+  return {
+    x: anchor.x + delta.x * scale,
+    y: anchor.y + delta.y * scale
+  };
+};
 
 const arrowPathForShape = (shape: ArrowShape, orientation: 'start' | 'end'): string | null => {
   switch (shape) {
@@ -228,6 +261,16 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
   const geometry = useMemo(
     () => previewGeometry ?? getConnectorPath(connector, source, target, nodes),
     [previewGeometry, connector, source, target, nodes]
+  );
+
+  const startHandleCenter = useMemo(
+    () => computeEndpointHandleCenter(geometry.points, 'start'),
+    [geometry]
+  );
+
+  const endHandleCenter = useMemo(
+    () => computeEndpointHandleCenter(geometry.points, 'end'),
+    [geometry]
   );
 
   const cornerRadius = connector.style.cornerRadius ?? 12;
@@ -554,15 +597,15 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
           >
             <circle
               className={`diagram-connector__endpoint-visual${startHovered ? ' is-hovered' : ''}`}
-              cx={geometry.start.x}
-              cy={geometry.start.y}
-              r={5.5}
+              cx={startHandleCenter.x}
+              cy={startHandleCenter.y}
+              r={ENDPOINT_VISUAL_RADIUS}
             />
             <circle
               className={`diagram-connector__endpoint-hit${startHovered ? ' is-hovered' : ''}`}
-              cx={geometry.start.x}
-              cy={geometry.start.y}
-              r={16}
+              cx={startHandleCenter.x}
+              cy={startHandleCenter.y}
+              r={ENDPOINT_HIT_RADIUS}
               onPointerEnter={() => setHoveredEndpoint('start')}
               onPointerLeave={() =>
                 setHoveredEndpoint((value) => (value === 'start' ? null : value))
@@ -579,15 +622,15 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
           >
             <circle
               className={`diagram-connector__endpoint-visual${endHovered ? ' is-hovered' : ''}`}
-              cx={geometry.end.x}
-              cy={geometry.end.y}
-              r={5.5}
+              cx={endHandleCenter.x}
+              cy={endHandleCenter.y}
+              r={ENDPOINT_VISUAL_RADIUS}
             />
             <circle
               className={`diagram-connector__endpoint-hit${endHovered ? ' is-hovered' : ''}`}
-              cx={geometry.end.x}
-              cy={geometry.end.y}
-              r={16}
+              cx={endHandleCenter.x}
+              cy={endHandleCenter.y}
+              r={ENDPOINT_HIT_RADIUS}
               onPointerEnter={() => setHoveredEndpoint('end')}
               onPointerLeave={() => setHoveredEndpoint((value) => (value === 'end' ? null : value))}
               onPointerDown={(event) => {

--- a/src/components/DiagramNode.tsx
+++ b/src/components/DiagramNode.tsx
@@ -108,7 +108,7 @@ export const DiagramNode: React.FC<DiagramNodeProps> = ({
 
   const cursor = tool === 'connector' ? 'crosshair' : 'move';
 
-  const connectorHandleOffset = 18;
+  const connectorHandleOffset = 20;
   const connectorAnchors = getConnectorPortPositions(node);
   const connectorHandles: Array<{ key: CardinalConnectorPort; x: number; y: number }> = CARDINAL_PORTS.map(
     (port) => {
@@ -130,7 +130,7 @@ export const DiagramNode: React.FC<DiagramNodeProps> = ({
       }
     }
   );
-  const connectorHandleRadius = 9;
+  const connectorHandleRadius = 11;
 
   const isLinkNode = node.shape === 'link';
   const isTextualNode = node.shape === 'text' || isLinkNode;

--- a/src/components/DiagramNode.tsx
+++ b/src/components/DiagramNode.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { CARDINAL_PORTS, getConnectorPortPositions } from '../utils/connector';
 import { CardinalConnectorPort, NodeModel, Tool } from '../types/scene';
 
 interface DiagramNodeProps {
@@ -108,12 +109,27 @@ export const DiagramNode: React.FC<DiagramNodeProps> = ({
   const cursor = tool === 'connector' ? 'crosshair' : 'move';
 
   const connectorHandleOffset = 18;
-  const connectorHandles: Array<{ key: CardinalConnectorPort; x: number; y: number }> = [
-    { key: 'top', x: node.size.width / 2, y: -connectorHandleOffset },
-    { key: 'right', x: node.size.width + connectorHandleOffset, y: node.size.height / 2 },
-    { key: 'bottom', x: node.size.width / 2, y: node.size.height + connectorHandleOffset },
-    { key: 'left', x: -connectorHandleOffset, y: node.size.height / 2 }
-  ];
+  const connectorAnchors = getConnectorPortPositions(node);
+  const connectorHandles: Array<{ key: CardinalConnectorPort; x: number; y: number }> = CARDINAL_PORTS.map(
+    (port) => {
+      const anchor = connectorAnchors[port];
+      const localX = anchor.x - node.position.x;
+      const localY = anchor.y - node.position.y;
+
+      switch (port) {
+        case 'top':
+          return { key: port, x: localX, y: localY - connectorHandleOffset };
+        case 'right':
+          return { key: port, x: localX + connectorHandleOffset, y: localY };
+        case 'bottom':
+          return { key: port, x: localX, y: localY + connectorHandleOffset };
+        case 'left':
+          return { key: port, x: localX - connectorHandleOffset, y: localY };
+        default:
+          return { key: port, x: localX, y: localY };
+      }
+    }
+  );
   const connectorHandleRadius = 9;
 
   const isLinkNode = node.shape === 'link';

--- a/src/utils/connector.ts
+++ b/src/utils/connector.ts
@@ -79,11 +79,27 @@ export const cloneConnectorEndpoint = (endpoint: ConnectorEndpoint): ConnectorEn
   throw new Error('Unsupported connector endpoint.');
 };
 
+const midpoint = (a: Vec2, b: Vec2): Vec2 => ({ x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 });
+
 export const getConnectorPortPositions = (
   node: NodeModel
 ): Record<CardinalConnectorPort, Vec2> => {
   const { position, size } = node;
   const center = getNodeCenter(node);
+
+  if (node.shape === 'triangle') {
+    const top: Vec2 = { x: position.x + size.width / 2, y: position.y };
+    const bottomLeft: Vec2 = { x: position.x, y: position.y + size.height };
+    const bottomRight: Vec2 = { x: position.x + size.width, y: position.y + size.height };
+
+    return {
+      top,
+      right: midpoint(top, bottomRight),
+      bottom: midpoint(bottomLeft, bottomRight),
+      left: midpoint(top, bottomLeft)
+    };
+  }
+
   return {
     top: { x: center.x, y: position.y },
     right: { x: position.x + size.width, y: center.y },


### PR DESCRIPTION
## Summary
- align triangle connector port positions with the triangle edges so connectors anchor on the shape instead of empty space
- derive connector handle placement from the calculated anchor points to keep UI handles aligned across shapes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d955e56214832d885e9aff465bc5a7