### PR TITLE
Add installable desktop experience with offline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Schematics Studio
 
-An experimental infinite-canvas diagram editor focused on building flowcharts, org charts, and lightweight schematic documents. The goal is to provide a Figma-like authoring experience optimised for nodes, connectors, and rapid iteration.
+An experimental infinite-canvas diagram editor focused on building flowcharts, org charts, and lightweight schematic documents.
+The goal is to provide a Figma-like authoring experience optimised for nodes, connectors, and rapid iteration.
 
 ## Getting Started
 
@@ -20,6 +21,16 @@ npm config set registry https://registry.npmmirror.com
 - `npm run dev` – start the Vite development server.
 - `npm run build` – type-check and produce a production build.
 - `npm run preview` – preview the build output locally.
+
+## Offline & Desktop installation
+
+Schematics Studio ships as an installable Progressive Web App (PWA). When you visit the site in a supported browser you will
+see an install card that automatically detects your operating system and explains the correct install flow (for example, “Add to
+Dock” on macOS or “Install app” in Chrome on Windows).
+
+For users who prefer a distributable archive, run `npm run build` and compress the generated `dist/` directory. The bundled
+assets are completely static and can be unzipped onto any machine for offline use or served behind an internal web server. See
+[`docs/desktop-offline.md`](docs/desktop-offline.md) for a step-by-step guide covering macOS packaging.
 
 ## Current Capabilities
 

--- a/docs/desktop-offline.md
+++ b/docs/desktop-offline.md
@@ -1,0 +1,53 @@
+# Desktop & Offline Distribution Guide
+
+This guide explains how to package Schematics Studio so teammates can install it locally (macOS example) and how the in-app
+installer works.
+
+## 1. Build the production bundle
+
+```bash
+npm install
+npm run build
+```
+
+The compiled files are emitted into `dist/`. Every asset is static, so the folder can be zipped and shared or hosted behind a
+simple file server.
+
+## 2. Create a macOS-friendly archive
+
+1. Open Finder and create a new folder such as `SchematicsStudio-macOS`.
+2. Copy the entire `dist/` directory contents into that folder.
+3. (Optional) Add a `README.txt` describing how to launch `index.html` locally or how to serve the folder with `npx serve dist`.
+4. Right-click the folder in Finder and choose **Compress “SchematicsStudio-macOS”** to produce `SchematicsStudio-macOS.zip`.
+5. Share the resulting zip. A user only needs to unzip it and open `index.html` in a modern browser. The service worker will
+   cache files after the first online session so boards remain available offline.
+
+## 3. Built-in installer behaviour
+
+- The login screen now surfaces an “Install on macOS” card (or Windows/Linux/etc.) that adapts instructions based on the
+  visitor’s platform.
+- Supported browsers fire the `beforeinstallprompt` event, enabling a one-click install button. When unavailable (Safari on
+  macOS/iOS), the card shows manual steps such as Safari’s **File → Add to Dock** flow.
+- Once installed, the Progressive Web App (PWA) runs in its own window and stores assets in the browser cache for offline work.
+
+## 4. Verifying offline readiness
+
+After installing the PWA or unzipping the archive:
+
+1. Sign in while connected to the internet so the app can cache the board data.
+2. Disconnect from the network and reload the installed app or `index.html` from the archive.
+3. You should still be able to open previously saved boards and make edits. Reconnect later to sync any changes.
+
+## 5. Automating archive creation (optional)
+
+You can automate zip creation inside CI/CD by adding a script similar to:
+
+```json
+{
+  "scripts": {
+    "package:zip": "npm run build && cd dist && zip -r ../schematics-studio-offline.zip ."
+  }
+}
+```
+
+This keeps binary artifacts out of source control but still produces a downloadable bundle for distribution.

--- a/index.html
+++ b/index.html
@@ -3,6 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#1d4ed8" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="icon" href="/icons/icon.svg" type="image/svg+xml" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+    <link rel="apple-touch-icon" href="/icons/icon.svg" />
     <title>Schematics Studio</title>
   </head>
   <body>

--- a/public/icons/icon.svg
+++ b/public/icons/icon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1d4ed8" />
+      <stop offset="100%" stop-color="#38bdf8" />
+    </linearGradient>
+  </defs>
+  <rect width="256" height="256" rx="56" fill="#020617" />
+  <path d="M64 64h64l32 32v64l-32 32H64l-32-32V96z" fill="url(#g)" opacity="0.9" />
+  <path d="M92 92h44l20 20v52l-20 20H92l-20-20v-52z" fill="none" stroke="#f8fafc" stroke-width="12" stroke-linejoin="round" />
+  <circle cx="96" cy="128" r="10" fill="#facc15" />
+  <circle cx="160" cy="160" r="10" fill="#f97316" />
+  <line x1="96" y1="128" x2="160" y2="160" stroke="#f8fafc" stroke-width="8" stroke-linecap="round" opacity="0.8" />
+</svg>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,17 @@
+{
+  "name": "Schematics Studio",
+  "short_name": "Schematics",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#020617",
+  "theme_color": "#1d4ed8",
+  "description": "Design and edit circuit schematics from any device, even offline.",
+  "icons": [
+    {
+      "src": "/icons/icon.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,54 @@
+const CACHE_NAME = 'schematics-app-cache-v1';
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((cacheNames) =>
+        Promise.all(
+          cacheNames
+            .filter((cacheName) => cacheName !== CACHE_NAME)
+            .map((cacheName) => caches.delete(cacheName))
+        )
+      )
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const request = event.request;
+  if (request.method !== 'GET' || request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
+    return;
+  }
+
+  event.respondWith(
+    caches.open(CACHE_NAME).then(async (cache) => {
+      const cachedResponse = await cache.match(request);
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+
+      try {
+        const networkResponse = await fetch(request);
+        if (
+          networkResponse &&
+          networkResponse.status === 200 &&
+          networkResponse.type === 'basic' &&
+          request.url.startsWith(self.location.origin)
+        ) {
+          cache.put(request, networkResponse.clone());
+        }
+        return networkResponse;
+      } catch (error) {
+        if (request.mode === 'navigate') {
+          return caches.match('/');
+        }
+        throw error;
+      }
+    })
+  );
+});

--- a/src/App.css
+++ b/src/App.css
@@ -445,3 +445,141 @@
   color: rgba(148, 163, 184, 0.85);
 }
 
+.auth-layout {
+  width: min(960px, 100%);
+  display: grid;
+  gap: 24px;
+  align-items: start;
+}
+
+@media (min-width: 960px) {
+  .auth-layout {
+    grid-template-columns: minmax(0, 360px) minmax(0, 1fr);
+  }
+}
+
+.desktop-download {
+  background: rgba(15, 23, 42, 0.88);
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 24px 60px rgba(2, 6, 23, 0.55);
+  padding: 28px;
+  color: #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.desktop-download__header {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.desktop-download__title {
+  font-size: 22px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.desktop-download__description {
+  margin: 0;
+  color: rgba(203, 213, 225, 0.75);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.desktop-download__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.desktop-download__button {
+  border: none;
+  border-radius: 14px;
+  padding: 12px 18px;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  color: #f8fafc;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.8), rgba(14, 165, 233, 0.8));
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.desktop-download__button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+  transform: none;
+  box-shadow: none;
+}
+
+.desktop-download__button:not(:disabled):hover,
+.desktop-download__button:not(:disabled):focus-visible {
+  outline: none;
+  transform: translateY(-1px);
+  box-shadow: 0 14px 30px rgba(59, 130, 246, 0.4);
+}
+
+.desktop-download__hint {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.desktop-download__status {
+  border-radius: 16px;
+  padding: 14px 16px;
+  background: rgba(22, 101, 52, 0.18);
+  border: 1px solid rgba(34, 197, 94, 0.35);
+  color: #bbf7d0;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.desktop-download__instructions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.desktop-download__instructions-title {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0;
+  color: rgba(226, 232, 240, 0.95);
+}
+
+.desktop-download__steps {
+  margin: 0;
+  padding-left: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  font-size: 14px;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.desktop-download__step {
+  line-height: 1.6;
+}
+
+.desktop-download__footnote {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.desktop-download__footnote code {
+  font-family: 'SFMono-Regular', Menlo, Consolas, monospace;
+  background: rgba(15, 23, 42, 0.7);
+  border-radius: 8px;
+  padding: 2px 6px;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+@media (max-width: 959px) {
+  .desktop-download {
+    padding: 24px;
+  }
+}

--- a/src/components/DesktopDownloadSection.tsx
+++ b/src/components/DesktopDownloadSection.tsx
@@ -1,48 +1,207 @@
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import useOperatingSystem, { OperatingSystem } from '../hooks/useOperatingSystem';
 
-const DESKTOP_ARCHIVE_PATH = 'desktop/schematics-studio.zip';
+interface BeforeInstallPromptEvent extends Event {
+  readonly platforms: string[];
+  prompt(): Promise<void>;
+  readonly userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+}
 
-const resolveDesktopAssetHref = (relativePath: string): string => {
-  const sanitizedPath = relativePath.replace(/^\/+/, '');
-  const baseUrl = import.meta.env.BASE_URL ?? '/';
-  const normalizedBase = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+type OsGuide = {
+  label: string;
+  manualHeading: string;
+  steps: string[];
+  fallbackMessage: string;
+};
 
+const OS_GUIDES: Record<OperatingSystem, OsGuide> = {
+  mac: {
+    label: 'macOS',
+    manualHeading: 'Install on macOS',
+    steps: [
+      'Open Schematics Studio in Safari or Chrome on your Mac.',
+      "In Safari: choose File → Add to Dock to create an app icon that opens offline.",
+      "In Chrome or Edge: look for the install icon in the address bar (or More ⋮ → 'Install app') and confirm the installation.",
+      'Launch the installed app from Applications (or Chrome Apps). It will cache your boards for offline work after the first sign-in.'
+    ],
+    fallbackMessage:
+      'If the install button is disabled, use Safari’s “Add to Dock” or Chrome’s install menu to add the app to macOS manually.'
+  },
+  windows: {
+    label: 'Windows',
+    manualHeading: 'Install on Windows',
+    steps: [
+      'Open this app in Microsoft Edge or Chrome.',
+      "Select the install icon in the address bar (or More ⋮ → 'Apps' → 'Install this site as an app').",
+      'Confirm the prompt. A Start menu entry will be created and the app will run offline after the first sync.'
+    ],
+    fallbackMessage:
+      'Open the app in Edge or Chrome and use the browser install menu if the automatic install button is not available.'
+  },
+  linux: {
+    label: 'Linux',
+    manualHeading: 'Install on Linux',
+    steps: [
+      'Open Schematics Studio in Chrome, Edge, or another Chromium-based browser.',
+      "Use the install icon in the address bar (or More ⋮ → 'Install app').",
+      'Confirm the installation. The app will appear in your launcher and stays available offline.'
+    ],
+    fallbackMessage:
+      'Use a Chromium-based browser and install the app from the address bar menu when the automatic button is not present.'
+  },
+  ios: {
+    label: 'iOS',
+    manualHeading: 'Install on iPhone or iPad',
+    steps: [
+      'Open this site in Safari on your device.',
+      "Tap the Share icon, then choose 'Add to Home Screen'.",
+      'Rename the shortcut if you like, then tap Add. Launching the shortcut opens the offline-capable app.'
+    ],
+    fallbackMessage: 'Use Safari’s Share menu → Add to Home Screen to install on iOS devices.'
+  },
+  android: {
+    label: 'Android',
+    manualHeading: 'Install on Android',
+    steps: [
+      'Open Schematics Studio in Chrome.',
+      "Tap the menu (⋮) and choose 'Install app' or 'Add to Home screen'.",
+      'Approve the prompt. The installed app caches data the next time you sign in while online.'
+    ],
+    fallbackMessage: 'Use Chrome’s menu → Install app to add it to your Android device.'
+  },
+  chromeos: {
+    label: 'ChromeOS',
+    manualHeading: 'Install on ChromeOS',
+    steps: [
+      'Open the app in Chrome.',
+      "Select the install icon in the address bar or More ⋮ → 'Install app'.",
+      'Confirm the installation. You can launch it from the app shelf even when you are offline.'
+    ],
+    fallbackMessage: 'Use Chrome’s install option from the address bar to add the app to ChromeOS.'
+  },
+  unknown: {
+    label: 'your device',
+    manualHeading: 'Install on your device',
+    steps: [
+      'Open Schematics Studio in a Chromium-based browser (Chrome, Edge) or Safari.',
+      "Look for an install option in the browser address bar or menu (for Safari on macOS use File → Add to Dock).",
+      'Confirm the prompt to finish installing the offline-ready app.'
+    ],
+    fallbackMessage:
+      'Open the site in a modern browser such as Chrome, Edge, or Safari and use the browser’s install option to add the app.'
+  }
+};
+
+const isStandaloneDisplayMode = (): boolean => {
   if (typeof window === 'undefined') {
-    return `${normalizedBase}${sanitizedPath}`;
+    return false;
   }
 
-  const absoluteBase = new URL(normalizedBase, window.location.href);
-  return new URL(sanitizedPath, absoluteBase).toString();
+  const mediaQuery = window.matchMedia('(display-mode: standalone)');
+  const navigatorAny = navigator as Navigator & { standalone?: boolean };
+  return mediaQuery.matches || Boolean(navigatorAny?.standalone);
 };
 
 export const DesktopDownloadSection: React.FC = () => {
-  const downloadLinkRef = useRef<HTMLAnchorElement | null>(null);
+  const operatingSystem = useOperatingSystem();
+  const [installPrompt, setInstallPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+  const [isInstalled, setIsInstalled] = useState<boolean>(isStandaloneDisplayMode());
 
-  const handleDownload = useCallback(() => {
-    const anchor = downloadLinkRef.current;
-    if (!anchor) {
+  useEffect(() => {
+    if (typeof window === 'undefined') {
       return;
     }
 
-    const resolvedHref = resolveDesktopAssetHref(DESKTOP_ARCHIVE_PATH);
-    anchor.href = resolvedHref;
-    anchor.download = DESKTOP_ARCHIVE_PATH.split('/').pop() ?? 'schematics-studio.zip';
-    anchor.rel = 'noopener noreferrer';
-    anchor.click();
+    const handleBeforeInstallPrompt = (event: Event) => {
+      event.preventDefault();
+      setInstallPrompt(event as BeforeInstallPromptEvent);
+    };
+
+    const handleAppInstalled = () => {
+      setIsInstalled(true);
+      setInstallPrompt(null);
+    };
+
+    const handleDisplayModeChange = () => {
+      setIsInstalled(isStandaloneDisplayMode());
+    };
+
+    window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt as EventListener);
+    window.addEventListener('appinstalled', handleAppInstalled);
+
+    const mediaQuery = window.matchMedia('(display-mode: standalone)');
+    mediaQuery.addEventListener('change', handleDisplayModeChange);
+
+    return () => {
+      window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt as EventListener);
+      window.removeEventListener('appinstalled', handleAppInstalled);
+      mediaQuery.removeEventListener('change', handleDisplayModeChange);
+    };
   }, []);
 
+  const guide = useMemo<OsGuide>(() => OS_GUIDES[operatingSystem], [operatingSystem]);
+
+  const handleInstall = useCallback(async () => {
+    if (!installPrompt) {
+      return;
+    }
+
+    await installPrompt.prompt();
+    await installPrompt.userChoice;
+    setInstallPrompt(null);
+  }, [installPrompt]);
+
+  const canAutoInstall = Boolean(installPrompt);
+
   return (
-    <section className="desktop-download">
-      <h2 className="desktop-download__title">Download the desktop app</h2>
-      <p className="desktop-download__description">
-        Get the latest Schematics Studio desktop build for offline editing.
-      </p>
-      <button type="button" className="desktop-download__button" onClick={handleDownload}>
-        Download for desktop
-      </button>
-      <a ref={downloadLinkRef} className="desktop-download__link" href="#" hidden aria-hidden="true">
-        Schematics Studio desktop download
-      </a>
+    <section className="desktop-download" aria-labelledby="desktop-download-title">
+      <div className="desktop-download__header">
+        <h2 id="desktop-download-title" className="desktop-download__title">
+          Work offline from your desktop
+        </h2>
+        <p className="desktop-download__description">
+          Install Schematics Studio as a desktop application tailored for {guide.label}. Once installed, the app
+          automatically caches your boards for offline editing after you sign in while online.
+        </p>
+      </div>
+
+      {isInstalled ? (
+        <div className="desktop-download__status" role="status">
+          <strong>Already installed.</strong> Launch the Schematics Studio app from your application launcher to work
+          offline any time.
+        </div>
+      ) : (
+        <div className="desktop-download__actions">
+          <button
+            type="button"
+            className="desktop-download__button"
+            onClick={handleInstall}
+            disabled={!canAutoInstall}
+          >
+            Install on {guide.label}
+          </button>
+          <p className="desktop-download__hint">
+            {canAutoInstall
+              ? 'Your browser will show an installation prompt. Accept it to add the app to your device.'
+              : guide.fallbackMessage}
+          </p>
+        </div>
+      )}
+
+      <div className="desktop-download__instructions" aria-live="polite">
+        <h3 className="desktop-download__instructions-title">{guide.manualHeading}</h3>
+        <ol className="desktop-download__steps">
+          {guide.steps.map((step, index) => (
+            <li key={index} className="desktop-download__step">
+              {step}
+            </li>
+          ))}
+        </ol>
+        <p className="desktop-download__footnote">
+          Need a packaged bundle instead? Run <code>npm run build</code> and compress the <code>dist/</code> folder to
+          distribute it as a zip for offline use.
+        </p>
+      </div>
     </section>
   );
 };

--- a/src/components/LoginScreen.tsx
+++ b/src/components/LoginScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useAuthStore } from '../state/authStore';
+import { DesktopDownloadSection } from './DesktopDownloadSection';
 
 export const LoginScreen: React.FC = () => {
   const login = useAuthStore((state) => state.login);
@@ -32,42 +33,45 @@ export const LoginScreen: React.FC = () => {
 
   return (
     <div className="auth-shell">
-      <form className="login-card" onSubmit={handleSubmit}>
-        <h1 className="login-card__title">Sign in</h1>
-        <p className="login-card__subtitle">Use the demo credentials to access your boards.</p>
-        <div className="login-card__field">
-          <label htmlFor="login-username">Username</label>
-          <input
-            id="login-username"
-            type="text"
-            autoComplete="username"
-            value={username}
-            onChange={handleUsernameChange}
-            placeholder="admin"
-            required
-          />
-        </div>
-        <div className="login-card__field">
-          <label htmlFor="login-password">Password</label>
-          <input
-            id="login-password"
-            type="password"
-            autoComplete="current-password"
-            value={password}
-            onChange={handlePasswordChange}
-            placeholder="password"
-            required
-          />
-        </div>
-        {error && <div className="login-card__error" role="alert">{error}</div>}
-        <button type="submit" className="login-card__submit">
-          Sign in
-        </button>
-        <div className="login-card__hint">
-          <span>Demo account</span>
-          <code>admin / password</code>
-        </div>
-      </form>
+      <div className="auth-layout">
+        <form className="login-card" onSubmit={handleSubmit}>
+          <h1 className="login-card__title">Sign in</h1>
+          <p className="login-card__subtitle">Use the demo credentials to access your boards.</p>
+          <div className="login-card__field">
+            <label htmlFor="login-username">Username</label>
+            <input
+              id="login-username"
+              type="text"
+              autoComplete="username"
+              value={username}
+              onChange={handleUsernameChange}
+              placeholder="admin"
+              required
+            />
+          </div>
+          <div className="login-card__field">
+            <label htmlFor="login-password">Password</label>
+            <input
+              id="login-password"
+              type="password"
+              autoComplete="current-password"
+              value={password}
+              onChange={handlePasswordChange}
+              placeholder="password"
+              required
+            />
+          </div>
+          {error && <div className="login-card__error" role="alert">{error}</div>}
+          <button type="submit" className="login-card__submit">
+            Sign in
+          </button>
+          <div className="login-card__hint">
+            <span>Demo account</span>
+            <code>admin / password</code>
+          </div>
+        </form>
+        <DesktopDownloadSection />
+      </div>
     </div>
   );
 };

--- a/src/hooks/useOperatingSystem.ts
+++ b/src/hooks/useOperatingSystem.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+
+export type OperatingSystem =
+  | 'mac'
+  | 'windows'
+  | 'linux'
+  | 'ios'
+  | 'android'
+  | 'chromeos'
+  | 'unknown';
+
+const detectOperatingSystem = (): OperatingSystem => {
+  if (typeof navigator === 'undefined') {
+    return 'unknown';
+  }
+
+  const { userAgent, platform } = navigator;
+  const normalized = userAgent.toLowerCase();
+  const platformLower = (platform ?? '').toLowerCase();
+
+  if (/iphone|ipad|ipod/.test(normalized)) {
+    return 'ios';
+  }
+
+  if (/android/.test(normalized)) {
+    return 'android';
+  }
+
+  if (/macintosh|macintel|macppc|mac68k/.test(platformLower) || /mac os x/.test(normalized)) {
+    return 'mac';
+  }
+
+  if (/win32|win64|windows|wince/.test(platformLower) || /windows/.test(normalized)) {
+    return 'windows';
+  }
+
+  if (/cros/.test(normalized)) {
+    return 'chromeos';
+  }
+
+  if (/linux/.test(platformLower) || /linux/.test(normalized)) {
+    return 'linux';
+  }
+
+  return 'unknown';
+};
+
+export const useOperatingSystem = (): OperatingSystem => {
+  const [operatingSystem, setOperatingSystem] = useState<OperatingSystem>(() => detectOperatingSystem());
+
+  useEffect(() => {
+    setOperatingSystem(detectOperatingSystem());
+  }, []);
+
+  return operatingSystem;
+};
+
+export default useOperatingSystem;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,3 +8,19 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     <App />
   </React.StrictMode>
 );
+
+const registerServiceWorker = async () => {
+  try {
+    await navigator.serviceWorker.register('/service-worker.js');
+  } catch (error) {
+    console.error('Service worker registration failed', error);
+  }
+};
+
+if ('serviceWorker' in navigator) {
+  if (import.meta.env.DEV) {
+    window.addEventListener('load', registerServiceWorker, { once: true });
+  } else {
+    registerServiceWorker();
+  }
+}


### PR DESCRIPTION
## Summary
- add a PWA manifest, service worker, and icon so the app can be installed and used offline
- surface a desktop installation section on the login screen that adapts instructions to the detected OS
- document how to package the offline bundle for desktop distribution

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68d970b04b0c832da71b166f60911e86