### PR TITLE
Add end connector arrow controls

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -117,6 +117,7 @@ const PENDING_CONNECTOR_STYLE: ConnectorModel['style'] = {
   strokeWidth: 2,
   dashed: false,
   startArrow: { shape: 'none', fill: 'filled' },
+  endArrow: { shape: 'none', fill: 'filled' },
   arrowSize: 1,
   cornerRadius: 12
 };
@@ -238,7 +239,8 @@ const cloneNodeForClipboard = (node: NodeModel): NodeModel => ({
 
 const cloneConnectorStyle = (style: ConnectorModel['style']): ConnectorModel['style'] => ({
   ...style,
-  startArrow: style.startArrow ? { ...style.startArrow } : undefined
+  startArrow: style.startArrow ? { ...style.startArrow } : undefined,
+  endArrow: style.endArrow ? { ...style.endArrow } : undefined
 });
 
 const cloneConnectorForClipboard = (connector: ConnectorModel): ConnectorModel => ({

--- a/src/components/ConnectorToolbar.tsx
+++ b/src/components/ConnectorToolbar.tsx
@@ -127,6 +127,10 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
   const startLockedFill = getLockedFillForShape(startShape);
   const startFillDisabled = startLockedFill !== null;
   const startFillValue = startLockedFill ?? connector.style.startArrow?.fill ?? 'filled';
+  const endShape = connector.style.endArrow?.shape ?? 'none';
+  const endLockedFill = getLockedFillForShape(endShape);
+  const endFillDisabled = endLockedFill !== null;
+  const endFillValue = endLockedFill ?? connector.style.endArrow?.fill ?? 'filled';
 
   const handleStrokeWidthChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = Number(event.target.value);
@@ -147,12 +151,24 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
     onStyleChange({ startArrow: shape });
   };
 
+  const handleEndArrowChange = (shape: ConnectorModel['style']['endArrow']) => {
+    onStyleChange({ endArrow: shape });
+  };
+
   const handleStartArrowShapeChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     const shape = event.target.value as ConnectorModel['style']['startArrow']['shape'];
     const current = connector.style.startArrow ?? { shape: 'none', fill: 'filled' };
     const lockedFill = getLockedFillForShape(shape);
     const nextFill = lockedFill ?? current.fill ?? 'filled';
     handleStartArrowChange({ ...current, shape, fill: nextFill });
+  };
+
+  const handleEndArrowShapeChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const shape = event.target.value as ConnectorModel['style']['endArrow']['shape'];
+    const current = connector.style.endArrow ?? { shape: 'none', fill: 'filled' };
+    const lockedFill = getLockedFillForShape(shape);
+    const nextFill = lockedFill ?? current.fill ?? 'filled';
+    handleEndArrowChange({ ...current, shape, fill: nextFill });
   };
 
   const handleStartArrowFillChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
@@ -163,6 +179,16 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
     const fill = event.target.value as ConnectorModel['style']['startArrow']['fill'];
     const current = connector.style.startArrow ?? { shape: 'none', fill: 'filled' };
     handleStartArrowChange({ ...current, fill });
+  };
+
+  const handleEndArrowFillChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const currentShape = connector.style.endArrow?.shape;
+    if (currentShape && getLockedFillForShape(currentShape)) {
+      return;
+    }
+    const fill = event.target.value as ConnectorModel['style']['endArrow']['fill'];
+    const current = connector.style.endArrow ?? { shape: 'none', fill: 'filled' };
+    handleEndArrowChange({ ...current, fill });
   };
 
   const handleArrowSizeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -268,6 +294,46 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
                 value={startFillValue}
                 onChange={handleStartArrowFillChange}
                 disabled={startFillDisabled}
+              >
+                {fillOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+        </section>
+        <section className="connector-toolbar__panel connector-toolbar__panel--end">
+          <h3 className="connector-toolbar__panel-title">End</h3>
+          <div className="connector-toolbar__section">
+            <label className="connector-toolbar__field connector-toolbar__field--block">
+              <span>Size</span>
+              <input
+                type="range"
+                min={0.5}
+                max={4}
+                step={0.1}
+                value={connector.style.arrowSize ?? 1}
+                onChange={handleArrowSizeChange}
+              />
+            </label>
+            <label className="connector-toolbar__field">
+              <span>Shape</span>
+              <select value={endShape} onChange={handleEndArrowShapeChange}>
+                {arrowOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="connector-toolbar__field">
+              <span>Fill</span>
+              <select
+                value={endFillValue}
+                onChange={handleEndArrowFillChange}
+                disabled={endFillDisabled}
               >
                 {fillOptions.map((option) => (
                   <option key={option.value} value={option.value}>

--- a/src/components/DiagramConnector.tsx
+++ b/src/components/DiagramConnector.tsx
@@ -345,10 +345,14 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
   const arrowSize = Math.max(0.6, connector.style.arrowSize ?? 1);
   const markerSize = 24 * arrowSize;
   const startMarkerId = useMemo(() => `connector-${connector.id}-start`, [connector.id]);
+  const endMarkerId = useMemo(() => `connector-${connector.id}-end`, [connector.id]);
 
   const startArrowShape = connector.style.startArrow?.shape ?? 'none';
   const startArrowFill =
     startArrowShape === 'line-arrow' ? 'outlined' : connector.style.startArrow?.fill ?? 'filled';
+  const endArrowShape = connector.style.endArrow?.shape ?? 'none';
+  const endArrowFill =
+    endArrowShape === 'line-arrow' ? 'outlined' : connector.style.endArrow?.fill ?? 'filled';
 
   const createMarker = (
     markerId: string,
@@ -402,6 +406,7 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
   };
 
   const startMarker = createMarker(startMarkerId, startArrowShape, startArrowFill, 'start');
+  const endMarker = createMarker(endMarkerId, endArrowShape, endArrowFill, 'end');
 
   const handleLabelInput = (event: React.FormEvent<HTMLDivElement>) => {
     setDraft(event.currentTarget.textContent ?? '');
@@ -515,6 +520,7 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
   const labelBackground = connector.labelStyle?.background ?? 'rgba(15,23,42,0.85)';
 
   const markerStartUrl = startArrowShape !== 'none' ? `url(#${startMarkerId})` : undefined;
+  const markerEndUrl = endArrowShape !== 'none' ? `url(#${endMarkerId})` : undefined;
 
   const trimmedLabel = connector.label?.trim() ?? '';
   const hasLabel = Boolean(trimmedLabel) || labelEditing;
@@ -546,7 +552,10 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
         ['--connector-width' as string]: `${connector.style.strokeWidth}`
       } as React.CSSProperties}
     >
-      <defs>{startMarker}</defs>
+      <defs>
+        {startMarker}
+        {endMarker}
+      </defs>
       <path className="diagram-connector__hit" d={hitPathData} strokeWidth={28} onPointerDown={onPointerDown} />
       {segments.map((segment) => {
         const isHovered = hoveredSegment === segment.index;
@@ -599,6 +608,7 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
         strokeWidth={connector.style.strokeWidth}
         strokeDasharray={connector.style.dashed ? '12 8' : undefined}
         markerStart={markerStartUrl}
+        markerEnd={markerEndUrl}
         onPointerDown={onPointerDown}
       />
       {selected && renderEndpoints && (

--- a/src/state/sceneStore.ts
+++ b/src/state/sceneStore.ts
@@ -122,13 +122,18 @@ const defaultConnectorStyle: ConnectorModel['style'] = {
   strokeWidth: 2,
   dashed: false,
   startArrow: { shape: 'none', fill: 'filled' },
+  endArrow: { shape: 'none', fill: 'filled' },
   arrowSize: 1,
   cornerRadius: 12
 };
 
-const connectorStyle = (startArrow?: ConnectorArrowStyle): ConnectorModel['style'] => ({
+const connectorStyle = (style: {
+  startArrow?: ConnectorArrowStyle;
+  endArrow?: ConnectorArrowStyle;
+} = {}): ConnectorModel['style'] => ({
   ...defaultConnectorStyle,
-  ...(startArrow ? { startArrow } : {})
+  ...(style.startArrow ? { startArrow: style.startArrow } : {}),
+  ...(style.endArrow ? { endArrow: style.endArrow } : {})
 });
 
 const defaultConnectorLabelStyle: ConnectorLabelStyle = {
@@ -152,7 +157,7 @@ const createInitialScene = (): SceneContent => {
       id: nanoid(),
       source: { nodeId: start.id, port: 'right' },
       target: { nodeId: collect.id, port: 'left' },
-      style: connectorStyle({ shape: 'triangle', fill: 'filled' }),
+      style: connectorStyle({ startArrow: { shape: 'triangle', fill: 'filled' } }),
       label: 'Begin',
       labelPosition: 0.5,
       labelOffset: 18,
@@ -162,7 +167,7 @@ const createInitialScene = (): SceneContent => {
       id: nanoid(),
       source: { nodeId: collect.id, port: 'right' },
       target: { nodeId: decision.id, port: 'left' },
-      style: connectorStyle({ shape: 'diamond', fill: 'outlined' }),
+      style: connectorStyle({ startArrow: { shape: 'diamond', fill: 'outlined' } }),
       label: 'Forward',
       labelPosition: 0.5,
       labelOffset: 18,
@@ -172,7 +177,7 @@ const createInitialScene = (): SceneContent => {
       id: nanoid(),
       source: { nodeId: decision.id, port: 'right' },
       target: { nodeId: done.id, port: 'left' },
-      style: connectorStyle({ shape: 'circle', fill: 'filled' }),
+      style: connectorStyle({ startArrow: { shape: 'circle', fill: 'filled' } }),
       label: 'Yes',
       labelPosition: 0.5,
       labelOffset: 18,
@@ -192,7 +197,7 @@ const createInitialScene = (): SceneContent => {
       id: nanoid(),
       source: { nodeId: review.id, port: 'left' },
       target: { nodeId: retry.id, port: 'right' },
-      style: connectorStyle({ shape: 'line-arrow', fill: 'outlined' }),
+      style: connectorStyle({ startArrow: { shape: 'line-arrow', fill: 'outlined' } }),
       label: 'Rework',
       labelPosition: 0.5,
       labelOffset: 18,
@@ -212,7 +217,7 @@ const createInitialScene = (): SceneContent => {
       id: nanoid(),
       source: { nodeId: decision.id, port: 'bottom' },
       target: { nodeId: notify.id, port: 'top' },
-      style: connectorStyle({ shape: 'triangle-inward', fill: 'filled' }),
+      style: connectorStyle({ startArrow: { shape: 'triangle-inward', fill: 'filled' } }),
       label: 'No',
       labelPosition: 0.5,
       labelOffset: 18,
@@ -222,7 +227,7 @@ const createInitialScene = (): SceneContent => {
       id: nanoid(),
       source: { nodeId: notify.id, port: 'right' },
       target: { position: { x: 620, y: 220 } },
-      style: connectorStyle({ shape: 'arrow', fill: 'filled' }),
+      style: connectorStyle({ startArrow: { shape: 'arrow', fill: 'filled' } }),
       label: 'Webhook',
       labelPosition: 0.5,
       labelOffset: 18,
@@ -232,7 +237,7 @@ const createInitialScene = (): SceneContent => {
       id: nanoid(),
       source: { nodeId: start.id, port: 'top' },
       target: { position: { x: -380, y: -360 } },
-      style: connectorStyle({ shape: 'triangle', fill: 'outlined' }),
+      style: connectorStyle({ startArrow: { shape: 'triangle', fill: 'outlined' } }),
       label: 'Monitoring',
       labelPosition: 0.5,
       labelOffset: 18,
@@ -324,7 +329,8 @@ export const useSceneStore = create<SceneStore>((set, get) => ({
           target: cloneConnectorEndpoint(connector.target),
           style: {
             ...connector.style,
-            startArrow: connector.style.startArrow ? { ...connector.style.startArrow } : undefined
+            startArrow: connector.style.startArrow ? { ...connector.style.startArrow } : undefined,
+            endArrow: connector.style.endArrow ? { ...connector.style.endArrow } : undefined
           },
           labelStyle: connector.labelStyle ? { ...connector.labelStyle } : undefined,
           points: connector.points?.map((point) => ({ ...point }))
@@ -584,7 +590,11 @@ export const useSceneStore = create<SceneStore>((set, get) => ({
         ...existing,
         source: cloneConnectorEndpoint(existing.source),
         target: cloneConnectorEndpoint(existing.target),
-        style: { ...existing.style },
+        style: {
+          ...existing.style,
+          startArrow: existing.style.startArrow ? { ...existing.style.startArrow } : undefined,
+          endArrow: existing.style.endArrow ? { ...existing.style.endArrow } : undefined
+        },
         labelStyle: existing.labelStyle ? { ...existing.labelStyle } : undefined,
         points: existing.points?.map((point) => ({ ...point }))
       };
@@ -592,7 +602,14 @@ export const useSceneStore = create<SceneStore>((set, get) => ({
       const { style, points, labelStyle, source, target, ...rest } = patch;
 
       if (style) {
-        nextConnector.style = { ...nextConnector.style, ...style };
+        const mergedStyle: ConnectorModel['style'] = { ...nextConnector.style, ...style };
+        if ('startArrow' in style) {
+          mergedStyle.startArrow = style.startArrow ? { ...style.startArrow } : undefined;
+        }
+        if ('endArrow' in style) {
+          mergedStyle.endArrow = style.endArrow ? { ...style.endArrow } : undefined;
+        }
+        nextConnector.style = mergedStyle;
       }
       if (labelStyle !== undefined) {
         nextConnector.labelStyle = labelStyle ? { ...labelStyle } : undefined;

--- a/src/types/scene.ts
+++ b/src/types/scene.ts
@@ -93,6 +93,7 @@ export interface ConnectorStyle {
   strokeWidth: number;
   dashed?: boolean;
   startArrow?: ConnectorArrowStyle;
+  endArrow?: ConnectorArrowStyle;
   arrowSize?: number;
   cornerRadius?: number;
 }

--- a/src/utils/__tests__/connector.test.ts
+++ b/src/utils/__tests__/connector.test.ts
@@ -40,6 +40,7 @@ const defaultConnectorStyle: Mutable<ConnectorModel['style']> = {
   strokeWidth: 2,
   dashed: false,
   startArrow: { shape: 'none', fill: 'filled' },
+  endArrow: { shape: 'none', fill: 'filled' },
   arrowSize: 1,
   cornerRadius: 12
 };

--- a/src/utils/scene.ts
+++ b/src/utils/scene.ts
@@ -175,6 +175,12 @@ export const cloneScene = (scene: SceneContent): SceneContent => ({
     ...connector,
     source: cloneConnectorEndpoint(connector.source),
     target: cloneConnectorEndpoint(connector.target),
+    style: {
+      ...connector.style,
+      startArrow: connector.style.startArrow ? { ...connector.style.startArrow } : undefined,
+      endArrow: connector.style.endArrow ? { ...connector.style.endArrow } : undefined
+    },
+    labelStyle: connector.labelStyle ? { ...connector.labelStyle } : undefined,
     points: connector.points?.map((point) => ({ ...point }))
   }))
 });


### PR DESCRIPTION
## Summary
- add an "End" section to the connector toolbar with independent shape and fill controls
- extend connector rendering and scene cloning to support end arrow markers
- include end arrow defaults across connector models and clipboard helpers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d9934f2e38832d82f451157eba7a4e