### PR TITLE
Add configurable connector end caps

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -116,7 +116,9 @@ const PENDING_CONNECTOR_STYLE: ConnectorModel['style'] = {
   stroke: '#e5e7eb',
   strokeWidth: 2,
   dashed: false,
-  cornerRadius: 12
+  cornerRadius: 12,
+  startCap: { shape: 'none', size: 14 },
+  endCap: { shape: 'none', size: 14 }
 };
 
 const MARQUEE_ACTIVATION_THRESHOLD = 2;
@@ -235,7 +237,9 @@ const cloneNodeForClipboard = (node: NodeModel): NodeModel => ({
 });
 
 const cloneConnectorStyle = (style: ConnectorModel['style']): ConnectorModel['style'] => ({
-  ...style
+  ...style,
+  startCap: style.startCap ? { ...style.startCap } : undefined,
+  endCap: style.endCap ? { ...style.endCap } : undefined
 });
 
 const cloneConnectorForClipboard = (connector: ConnectorModel): ConnectorModel => ({

--- a/src/styles/canvas.css
+++ b/src/styles/canvas.css
@@ -337,6 +337,34 @@
   stroke-width: 1.8;
 }
 
+.diagram-connector__cap {
+  pointer-events: none;
+  transform-box: fill-box;
+  transform-origin: center;
+  transition: opacity 0.18s ease, filter 0.18s ease;
+}
+
+.diagram-connector__cap-shape {
+  pointer-events: none;
+  transition: fill 0.18s ease, stroke 0.18s ease;
+}
+
+body[data-connector-cap-focus='start'] .diagram-connector__cap[data-endpoint='start'],
+body[data-connector-cap-focus='start']
+  .diagram-connector__endpoint-group[data-endpoint='start']
+  .diagram-connector__endpoint-visual {
+  filter: drop-shadow(0 0 8px rgba(96, 165, 250, 0.55));
+  opacity: 1;
+}
+
+body[data-connector-cap-focus='end'] .diagram-connector__cap[data-endpoint='end'],
+body[data-connector-cap-focus='end']
+  .diagram-connector__endpoint-group[data-endpoint='end']
+  .diagram-connector__endpoint-visual {
+  filter: drop-shadow(0 0 8px rgba(244, 114, 182, 0.5));
+  opacity: 1;
+}
+
 .diagram-connector__label-leader {
   stroke: rgba(148, 163, 184, 0.55);
   stroke-width: 1.5;

--- a/src/styles/connector-toolbar.css
+++ b/src/styles/connector-toolbar.css
@@ -126,3 +126,86 @@
   min-width: calc(92px * var(--menu-scale));
 }
 
+.connector-toolbar__panel--caps {
+  flex: 1 1 calc(320px * var(--menu-scale));
+}
+
+.connector-toolbar__caps {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(calc(200px * var(--menu-scale)), 1fr));
+  gap: calc(12px * var(--menu-scale));
+}
+
+.connector-toolbar__cap-group {
+  display: flex;
+  flex-direction: column;
+  gap: calc(10px * var(--menu-scale));
+  padding: calc(10px * var(--menu-scale));
+  border-radius: calc(10px * var(--menu-scale));
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.35);
+  transition: border 0.18s ease, background 0.18s ease, box-shadow 0.18s ease;
+}
+
+.connector-toolbar__cap-group[data-active] {
+  border-color: rgba(147, 197, 253, 0.55);
+  background: rgba(30, 64, 175, 0.32);
+  box-shadow: 0 0 0 1px rgba(96, 165, 250, 0.25);
+}
+
+.connector-toolbar__cap-heading {
+  display: flex;
+  align-items: center;
+  gap: calc(10px * var(--menu-scale));
+}
+
+.connector-toolbar__cap-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: calc(32px * var(--menu-scale));
+  height: calc(32px * var(--menu-scale));
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.16);
+  font-size: calc(14px * var(--menu-scale));
+}
+
+.connector-toolbar__cap-icon--start {
+  color: rgba(96, 165, 250, 0.92);
+}
+
+.connector-toolbar__cap-icon--end {
+  color: rgba(244, 114, 182, 0.92);
+}
+
+.connector-toolbar__cap-text {
+  display: flex;
+  flex-direction: column;
+  gap: calc(2px * var(--menu-scale));
+}
+
+.connector-toolbar__cap-text span {
+  font-size: calc(13px * var(--menu-scale));
+  font-weight: 600;
+  color: #e2e8f0;
+}
+
+.connector-toolbar__cap-text small {
+  font-size: calc(11px * var(--menu-scale));
+  color: rgba(226, 232, 240, 0.55);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.connector-toolbar__field--slider span {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
+.connector-toolbar__field--slider span strong {
+  font-size: calc(12px * var(--menu-scale));
+  color: rgba(226, 232, 240, 0.75);
+}
+

--- a/src/types/scene.ts
+++ b/src/types/scene.ts
@@ -73,11 +73,26 @@ export interface ConnectorLabelStyle {
   background: string;
 }
 
+export type ConnectorEndpointShape =
+  | 'none'
+  | 'arrow'
+  | 'triangle'
+  | 'open-arrow'
+  | 'diamond'
+  | 'circle';
+
+export interface ConnectorEndpointStyle {
+  shape: ConnectorEndpointShape;
+  size: number;
+}
+
 export interface ConnectorStyle {
   stroke: string;
   strokeWidth: number;
   dashed?: boolean;
   cornerRadius?: number;
+  startCap?: ConnectorEndpointStyle;
+  endCap?: ConnectorEndpointStyle;
 }
 
 export interface ConnectorModel {


### PR DESCRIPTION
## Summary
- add connector endpoint cap styles and defaults to the scene store and canvas helpers
- render arrow, triangle, outline arrow, diamond, and circle caps per end with selection highlighting
- extend the connector toolbar with independent start/end controls and hover cues for each cap

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d9b8d492dc832d880c55f6acc9f6c3