### PR TITLE
Refine connector toolbar layout

### DIFF
--- a/src/components/ConnectorToolbar.tsx
+++ b/src/components/ConnectorToolbar.tsx
@@ -222,8 +222,8 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
         </section>
         <section className="connector-toolbar__panel connector-toolbar__panel--endpoints">
           <h3 className="connector-toolbar__panel-title">Endpoints</h3>
-          <div className="connector-toolbar__section connector-toolbar__section--endpoints">
-            <div className="connector-toolbar__endpoint-group" data-endpoint="start">
+          <div className="connector-toolbar__endpoints">
+            <div className="connector-toolbar__endpoint" data-endpoint="start">
               <div className="connector-toolbar__endpoint-header">
                 <span className="connector-toolbar__endpoint-title">Start</span>
                 <span className="connector-toolbar__endpoint-direction">Source end</span>
@@ -241,18 +241,20 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
                   ))}
                 </select>
               </label>
-              <label className="connector-toolbar__field">
+              <label className="connector-toolbar__field connector-toolbar__field--slider">
                 <span>Size</span>
                 <input
-                  type="number"
+                  type="range"
                   min={6}
                   max={48}
+                  step={1}
                   value={startCap.size}
                   onChange={(event) => handleEndpointSizeChange('start', event)}
                 />
+                <span className="connector-toolbar__value">{startCap.size}px</span>
               </label>
             </div>
-            <div className="connector-toolbar__endpoint-group" data-endpoint="end">
+            <div className="connector-toolbar__endpoint" data-endpoint="end">
               <div className="connector-toolbar__endpoint-header">
                 <span className="connector-toolbar__endpoint-title">End</span>
                 <span className="connector-toolbar__endpoint-direction">Target end</span>
@@ -267,15 +269,17 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
                   ))}
                 </select>
               </label>
-              <label className="connector-toolbar__field">
+              <label className="connector-toolbar__field connector-toolbar__field--slider">
                 <span>Size</span>
                 <input
-                  type="number"
+                  type="range"
                   min={6}
                   max={48}
+                  step={1}
                   value={endCap.size}
                   onChange={(event) => handleEndpointSizeChange('end', event)}
                 />
+                <span className="connector-toolbar__value">{endCap.size}px</span>
               </label>
             </div>
           </div>

--- a/src/styles/connector-toolbar.css
+++ b/src/styles/connector-toolbar.css
@@ -14,14 +14,15 @@
   color: #e2e8f0;
   pointer-events: auto;
   will-change: transform;
-  min-width: calc(300px * var(--menu-scale));
-  max-width: calc(560px * var(--menu-scale));
+  min-width: calc(280px * var(--menu-scale));
+  max-width: calc(640px * var(--menu-scale));
 }
 
 .connector-toolbar__content {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(calc(240px * var(--menu-scale)), 1fr));
   gap: calc(12px * var(--menu-scale));
+  align-items: stretch;
 }
 
 .connector-toolbar__panel {
@@ -55,22 +56,21 @@
   row-gap: calc(8px * var(--menu-scale));
 }
 
-.connector-toolbar__section--endpoints {
-  align-items: stretch;
-  gap: calc(16px * var(--menu-scale));
-}
-
-.connector-toolbar__endpoint-group {
+.connector-toolbar__endpoints {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: calc(12px * var(--menu-scale));
   background: rgba(15, 23, 42, 0.45);
   border: 1px solid rgba(148, 163, 184, 0.18);
   border-radius: calc(10px * var(--menu-scale));
-  padding: calc(10px * var(--menu-scale));
+  padding: calc(12px * var(--menu-scale));
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.25);
+}
+
+.connector-toolbar__endpoint {
   display: flex;
   flex-direction: column;
   gap: calc(8px * var(--menu-scale));
-  flex: 1 1 calc(180px * var(--menu-scale));
-  min-width: calc(160px * var(--menu-scale));
-  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.25);
 }
 
 .connector-toolbar__endpoint-header {
@@ -87,14 +87,14 @@
   gap: calc(6px * var(--menu-scale));
 }
 
-.connector-toolbar__endpoint-group[data-endpoint='start']
+.connector-toolbar__endpoint[data-endpoint='start']
   .connector-toolbar__endpoint-title::after {
   content: '←';
   font-size: calc(12px * var(--menu-scale));
   opacity: 0.7;
 }
 
-.connector-toolbar__endpoint-group[data-endpoint='end']
+.connector-toolbar__endpoint[data-endpoint='end']
   .connector-toolbar__endpoint-title::after {
   content: '→';
   font-size: calc(12px * var(--menu-scale));
@@ -125,6 +125,13 @@
   flex: 0 0 auto;
 }
 
+.connector-toolbar__field--slider {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: calc(8px * var(--menu-scale));
+}
+
 .connector-toolbar__field input[type='number'],
 .connector-toolbar__field select,
 .connector-toolbar__field input[type='range'] {
@@ -142,6 +149,14 @@
 .connector-toolbar__field input[type='range'] {
   min-width: 0;
   width: 100%;
+}
+
+.connector-toolbar__value {
+  font-size: calc(11px * var(--menu-scale));
+  color: rgba(226, 232, 240, 0.75);
+  min-width: calc(40px * var(--menu-scale));
+  text-align: right;
+  font-variant-numeric: tabular-nums;
 }
 
 .connector-toolbar__field input[type='color'] {
@@ -177,5 +192,15 @@
 .connector-toolbar__button--toggle {
   flex: 0 0 auto;
   min-width: calc(92px * var(--menu-scale));
+}
+
+@media (max-width: 720px) {
+  .connector-toolbar__content {
+    grid-template-columns: 1fr;
+  }
+
+  .connector-toolbar__endpoints {
+    grid-template-columns: 1fr;
+  }
 }
 


### PR DESCRIPTION
## Summary
- convert connector endpoint size inputs to range sliders with inline value readouts
- reorganize the connector toolbar layout so stroke and endpoint controls sit in a tighter horizontal grid
- refresh connector toolbar styling to reduce wasted space and keep the start/end controls within a single grouped panel

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68daa815f4ac832db7971f50552abaec