### PR TITLE
Redesign connector toolbar layout and controls

### DIFF
--- a/src/components/ConnectorToolbar.tsx
+++ b/src/components/ConnectorToolbar.tsx
@@ -161,6 +161,16 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
     { value: 'circle', label: 'Circle' }
   ];
 
+  const endpointGroups: Array<{
+    endpoint: 'start' | 'end';
+    cap: ConnectorEndpointCap;
+    title: string;
+    direction: string;
+  }> = [
+    { endpoint: 'start', cap: startCap, title: 'Start', direction: 'Source end' },
+    { endpoint: 'end', cap: endCap, title: 'End', direction: 'Target end' }
+  ];
+
   return (
     <div
       ref={toolbarRef}
@@ -182,7 +192,7 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
       <div className="connector-toolbar__content">
         <section className="connector-toolbar__panel connector-toolbar__panel--stroke">
           <h3 className="connector-toolbar__panel-title">Stroke</h3>
-          <div className="connector-toolbar__section">
+          <div className="connector-toolbar__section connector-toolbar__section--stroke">
             <label className="connector-toolbar__field">
               <span>Width</span>
               <input
@@ -223,61 +233,45 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
         <section className="connector-toolbar__panel connector-toolbar__panel--endpoints">
           <h3 className="connector-toolbar__panel-title">Endpoints</h3>
           <div className="connector-toolbar__section connector-toolbar__section--endpoints">
-            <div className="connector-toolbar__endpoint-group" data-endpoint="start">
-              <div className="connector-toolbar__endpoint-header">
-                <span className="connector-toolbar__endpoint-title">Start</span>
-                <span className="connector-toolbar__endpoint-direction">Source end</span>
+            {endpointGroups.map((group) => (
+              <div
+                key={group.endpoint}
+                className="connector-toolbar__endpoint-group"
+                data-endpoint={group.endpoint}
+              >
+                <div className="connector-toolbar__endpoint-header">
+                  <span className="connector-toolbar__endpoint-title">{group.title}</span>
+                  <span className="connector-toolbar__endpoint-direction">{group.direction}</span>
+                </div>
+                <label className="connector-toolbar__field">
+                  <span>Shape</span>
+                  <select
+                    value={group.cap.shape}
+                    onChange={(event) => handleEndpointShapeChange(group.endpoint, event)}
+                  >
+                    {shapeOptions.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="connector-toolbar__field connector-toolbar__field--slider">
+                  <span>Size</span>
+                  <div className="connector-toolbar__slider">
+                    <input
+                      type="range"
+                      min={6}
+                      max={48}
+                      step={1}
+                      value={group.cap.size}
+                      onChange={(event) => handleEndpointSizeChange(group.endpoint, event)}
+                    />
+                    <span className="connector-toolbar__slider-value">{group.cap.size}px</span>
+                  </div>
+                </label>
               </div>
-              <label className="connector-toolbar__field">
-                <span>Shape</span>
-                <select
-                  value={startCap.shape}
-                  onChange={(event) => handleEndpointShapeChange('start', event)}
-                >
-                  {shapeOptions.map((option) => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label className="connector-toolbar__field">
-                <span>Size</span>
-                <input
-                  type="number"
-                  min={6}
-                  max={48}
-                  value={startCap.size}
-                  onChange={(event) => handleEndpointSizeChange('start', event)}
-                />
-              </label>
-            </div>
-            <div className="connector-toolbar__endpoint-group" data-endpoint="end">
-              <div className="connector-toolbar__endpoint-header">
-                <span className="connector-toolbar__endpoint-title">End</span>
-                <span className="connector-toolbar__endpoint-direction">Target end</span>
-              </div>
-              <label className="connector-toolbar__field">
-                <span>Shape</span>
-                <select value={endCap.shape} onChange={(event) => handleEndpointShapeChange('end', event)}>
-                  {shapeOptions.map((option) => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label className="connector-toolbar__field">
-                <span>Size</span>
-                <input
-                  type="number"
-                  min={6}
-                  max={48}
-                  value={endCap.size}
-                  onChange={(event) => handleEndpointSizeChange('end', event)}
-                />
-              </label>
-            </div>
+            ))}
           </div>
         </section>
       </div>

--- a/src/styles/connector-toolbar.css
+++ b/src/styles/connector-toolbar.css
@@ -9,19 +9,20 @@
   padding: calc(12px * var(--menu-scale)) calc(16px * var(--menu-scale));
   display: flex;
   flex-direction: column;
-  gap: calc(12px * var(--menu-scale));
+  gap: calc(10px * var(--menu-scale));
   box-shadow: 0 24px 48px rgba(2, 6, 23, 0.5);
   color: #e2e8f0;
   pointer-events: auto;
   will-change: transform;
-  min-width: calc(300px * var(--menu-scale));
-  max-width: calc(560px * var(--menu-scale));
+  min-width: calc(420px * var(--menu-scale));
+  max-width: calc(680px * var(--menu-scale));
 }
 
 .connector-toolbar__content {
   display: flex;
-  flex-wrap: wrap;
+  align-items: stretch;
   gap: calc(12px * var(--menu-scale));
+  flex-wrap: nowrap;
 }
 
 .connector-toolbar__panel {
@@ -32,8 +33,8 @@
   display: flex;
   flex-direction: column;
   gap: calc(10px * var(--menu-scale));
-  flex: 1 1 calc(200px * var(--menu-scale));
-  min-width: calc(180px * var(--menu-scale));
+  flex: 1 1 0;
+  min-width: calc(200px * var(--menu-scale));
 }
 
 .connector-toolbar__panel-title {
@@ -55,9 +56,18 @@
   row-gap: calc(8px * var(--menu-scale));
 }
 
+.connector-toolbar__section--stroke {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(calc(120px * var(--menu-scale)), 1fr));
+  align-items: center;
+  column-gap: calc(10px * var(--menu-scale));
+  row-gap: calc(8px * var(--menu-scale));
+}
+
 .connector-toolbar__section--endpoints {
-  align-items: stretch;
-  gap: calc(16px * var(--menu-scale));
+  display: grid;
+  grid-template-columns: repeat(2, minmax(calc(180px * var(--menu-scale)), 1fr));
+  gap: calc(12px * var(--menu-scale));
 }
 
 .connector-toolbar__endpoint-group {
@@ -117,12 +127,32 @@
   min-width: calc(140px * var(--menu-scale));
 }
 
+.connector-toolbar__field--slider {
+  flex-direction: column;
+  align-items: stretch;
+  gap: calc(6px * var(--menu-scale));
+}
+
 .connector-toolbar__field--block {
   flex: 1 1 100%;
 }
 
 .connector-toolbar__field--color {
   flex: 0 0 auto;
+}
+
+.connector-toolbar__slider {
+  display: flex;
+  align-items: center;
+  gap: calc(8px * var(--menu-scale));
+}
+
+.connector-toolbar__slider-value {
+  font-size: calc(11px * var(--menu-scale));
+  color: rgba(226, 232, 240, 0.8);
+  min-width: calc(44px * var(--menu-scale));
+  text-align: right;
+  font-variant-numeric: tabular-nums;
 }
 
 .connector-toolbar__field input[type='number'],
@@ -177,5 +207,38 @@
 .connector-toolbar__button--toggle {
   flex: 0 0 auto;
   min-width: calc(92px * var(--menu-scale));
+  justify-self: stretch;
+}
+
+.connector-toolbar__section--stroke .connector-toolbar__field--block {
+  grid-column: 1 / -1;
+}
+
+.connector-toolbar__section--stroke .connector-toolbar__field--color {
+  justify-self: start;
+}
+
+.connector-toolbar__section--stroke .connector-toolbar__button--toggle {
+  justify-self: stretch;
+}
+
+@media (max-width: 840px) {
+  .connector-toolbar {
+    min-width: calc(360px * var(--menu-scale));
+  }
+
+  .connector-toolbar__content {
+    flex-wrap: wrap;
+  }
+
+  .connector-toolbar__section--endpoints {
+    grid-template-columns: repeat(1, minmax(calc(180px * var(--menu-scale)), 1fr));
+  }
+}
+
+@media (max-width: 560px) {
+  .connector-toolbar__section--stroke {
+    grid-template-columns: repeat(2, minmax(calc(120px * var(--menu-scale)), 1fr));
+  }
 }
 


### PR DESCRIPTION
## Summary
- redesign the connector toolbar content into a horizontal layout with tighter spacing
- add slider-based endpoint sizing with live value display for each connector end

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68daae132bfc832d81b6d131c06dd8f3