### PR TITLE
Restructure connector toolbar layout

### DIFF
--- a/src/components/ConnectorToolbar.tsx
+++ b/src/components/ConnectorToolbar.tsx
@@ -220,64 +220,69 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
             </label>
           </div>
         </section>
-        <section className="connector-toolbar__panel connector-toolbar__panel--endpoints">
-          <h3 className="connector-toolbar__panel-title">Endpoints</h3>
-          <div className="connector-toolbar__section connector-toolbar__section--endpoints">
-            <div className="connector-toolbar__endpoint-group" data-endpoint="start">
-              <div className="connector-toolbar__endpoint-header">
-                <span className="connector-toolbar__endpoint-title">Start</span>
-                <span className="connector-toolbar__endpoint-direction">Source end</span>
-              </div>
-              <label className="connector-toolbar__field">
-                <span>Shape</span>
-                <select
-                  value={startCap.shape}
-                  onChange={(event) => handleEndpointShapeChange('start', event)}
-                >
-                  {shapeOptions.map((option) => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label className="connector-toolbar__field">
-                <span>Size</span>
-                <input
-                  type="number"
-                  min={6}
-                  max={48}
-                  value={startCap.size}
-                  onChange={(event) => handleEndpointSizeChange('start', event)}
-                />
-              </label>
-            </div>
-            <div className="connector-toolbar__endpoint-group" data-endpoint="end">
-              <div className="connector-toolbar__endpoint-header">
-                <span className="connector-toolbar__endpoint-title">End</span>
-                <span className="connector-toolbar__endpoint-direction">Target end</span>
-              </div>
-              <label className="connector-toolbar__field">
-                <span>Shape</span>
-                <select value={endCap.shape} onChange={(event) => handleEndpointShapeChange('end', event)}>
-                  {shapeOptions.map((option) => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label className="connector-toolbar__field">
-                <span>Size</span>
-                <input
-                  type="number"
-                  min={6}
-                  max={48}
-                  value={endCap.size}
-                  onChange={(event) => handleEndpointSizeChange('end', event)}
-                />
-              </label>
-            </div>
+        <section
+          className="connector-toolbar__panel connector-toolbar__panel--endpoint"
+          data-endpoint="start"
+        >
+          <div className="connector-toolbar__endpoint-header">
+            <h3 className="connector-toolbar__panel-title">Start</h3>
+            <span className="connector-toolbar__endpoint-direction">Source end</span>
+          </div>
+          <div className="connector-toolbar__section connector-toolbar__section--endpoint">
+            <label className="connector-toolbar__field">
+              <span>Shape</span>
+              <select
+                value={startCap.shape}
+                onChange={(event) => handleEndpointShapeChange('start', event)}
+              >
+                {shapeOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="connector-toolbar__field">
+              <span>Size</span>
+              <input
+                type="number"
+                min={6}
+                max={48}
+                value={startCap.size}
+                onChange={(event) => handleEndpointSizeChange('start', event)}
+              />
+            </label>
+          </div>
+        </section>
+        <section
+          className="connector-toolbar__panel connector-toolbar__panel--endpoint"
+          data-endpoint="end"
+        >
+          <div className="connector-toolbar__endpoint-header">
+            <h3 className="connector-toolbar__panel-title">End</h3>
+            <span className="connector-toolbar__endpoint-direction">Target end</span>
+          </div>
+          <div className="connector-toolbar__section connector-toolbar__section--endpoint">
+            <label className="connector-toolbar__field">
+              <span>Shape</span>
+              <select value={endCap.shape} onChange={(event) => handleEndpointShapeChange('end', event)}>
+                {shapeOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="connector-toolbar__field">
+              <span>Size</span>
+              <input
+                type="number"
+                min={6}
+                max={48}
+                value={endCap.size}
+                onChange={(event) => handleEndpointSizeChange('end', event)}
+              />
+            </label>
           </div>
         </section>
       </div>

--- a/src/styles/connector-toolbar.css
+++ b/src/styles/connector-toolbar.css
@@ -14,14 +14,15 @@
   color: #e2e8f0;
   pointer-events: auto;
   will-change: transform;
-  min-width: calc(300px * var(--menu-scale));
-  max-width: calc(560px * var(--menu-scale));
+  min-width: calc(520px * var(--menu-scale));
+  max-width: calc(640px * var(--menu-scale));
 }
 
 .connector-toolbar__content {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: calc(12px * var(--menu-scale));
+  align-items: stretch;
 }
 
 .connector-toolbar__panel {
@@ -32,8 +33,8 @@
   display: flex;
   flex-direction: column;
   gap: calc(10px * var(--menu-scale));
-  flex: 1 1 calc(200px * var(--menu-scale));
-  min-width: calc(180px * var(--menu-scale));
+  flex: 1 1 calc(160px * var(--menu-scale));
+  min-width: calc(160px * var(--menu-scale));
 }
 
 .connector-toolbar__panel-title {
@@ -42,6 +43,9 @@
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: rgba(226, 232, 240, 0.7);
+  display: inline-flex;
+  align-items: center;
+  gap: calc(6px * var(--menu-scale));
 }
 
 .connector-toolbar__section {
@@ -55,47 +59,31 @@
   row-gap: calc(8px * var(--menu-scale));
 }
 
-.connector-toolbar__section--endpoints {
-  align-items: stretch;
-  gap: calc(16px * var(--menu-scale));
+.connector-toolbar__panel--endpoint {
+  gap: calc(12px * var(--menu-scale));
 }
 
-.connector-toolbar__endpoint-group {
-  background: rgba(15, 23, 42, 0.45);
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  border-radius: calc(10px * var(--menu-scale));
-  padding: calc(10px * var(--menu-scale));
-  display: flex;
+.connector-toolbar__section--endpoint {
   flex-direction: column;
-  gap: calc(8px * var(--menu-scale));
-  flex: 1 1 calc(180px * var(--menu-scale));
-  min-width: calc(160px * var(--menu-scale));
-  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.25);
+  align-items: stretch;
+  gap: calc(12px * var(--menu-scale));
 }
 
 .connector-toolbar__endpoint-header {
   display: flex;
   flex-direction: column;
-  gap: calc(2px * var(--menu-scale));
+  gap: calc(4px * var(--menu-scale));
 }
 
-.connector-toolbar__endpoint-title {
-  font-size: calc(13px * var(--menu-scale));
-  font-weight: 600;
-  display: inline-flex;
-  align-items: center;
-  gap: calc(6px * var(--menu-scale));
-}
-
-.connector-toolbar__endpoint-group[data-endpoint='start']
-  .connector-toolbar__endpoint-title::after {
+.connector-toolbar__panel--endpoint[data-endpoint='start']
+  .connector-toolbar__panel-title::after {
   content: '←';
   font-size: calc(12px * var(--menu-scale));
   opacity: 0.7;
 }
 
-.connector-toolbar__endpoint-group[data-endpoint='end']
-  .connector-toolbar__endpoint-title::after {
+.connector-toolbar__panel--endpoint[data-endpoint='end']
+  .connector-toolbar__panel-title::after {
   content: '→';
   font-size: calc(12px * var(--menu-scale));
   opacity: 0.7;


### PR DESCRIPTION
## Summary
- split the connector toolbar into dedicated stroke, start, and end panels arranged side-by-side
- update endpoint markup and styles to streamline spacing while preserving directional cues

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68dad33765f8832d8093c70cb3012238