### PR TITLE
Use sliders for connector endpoint size controls

### DIFF
--- a/src/components/ConnectorToolbar.tsx
+++ b/src/components/ConnectorToolbar.tsx
@@ -242,12 +242,13 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
                 ))}
               </select>
             </label>
-            <label className="connector-toolbar__field">
+            <label className="connector-toolbar__field connector-toolbar__field--block">
               <span>Size</span>
               <input
-                type="number"
+                type="range"
                 min={6}
                 max={48}
+                step={1}
                 value={startCap.size}
                 onChange={(event) => handleEndpointSizeChange('start', event)}
               />
@@ -273,12 +274,13 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
                 ))}
               </select>
             </label>
-            <label className="connector-toolbar__field">
+            <label className="connector-toolbar__field connector-toolbar__field--block">
               <span>Size</span>
               <input
-                type="number"
+                type="range"
                 min={6}
                 max={48}
+                step={1}
                 value={endCap.size}
                 onChange={(event) => handleEndpointSizeChange('end', event)}
               />


### PR DESCRIPTION
## Summary
- replace the connector endpoint size number inputs with range sliders to mirror the stroke corner control

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68dad78da010832dac3cf4480cb5a17e