### PR TITLE
Improve connector toolbar endpoint sizing controls

### DIFF
--- a/src/components/ConnectorToolbar.tsx
+++ b/src/components/ConnectorToolbar.tsx
@@ -200,7 +200,7 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
             </label>
             <button
               type="button"
-              className={`connector-toolbar__button connector-toolbar__button--toggle${
+              className={`connector-toolbar__button connector-toolbar__button--toggle connector-toolbar__button--block${
                 connector.style.dashed ? ' is-active' : ''
               }`}
               onClick={handleDashToggle}
@@ -242,12 +242,16 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
                 ))}
               </select>
             </label>
-            <label className="connector-toolbar__field">
-              <span>Size</span>
+            <label className="connector-toolbar__field connector-toolbar__field--block connector-toolbar__field--slider">
+              <div className="connector-toolbar__field-header">
+                <span>Size</span>
+                <span className="connector-toolbar__value">{startCap.size}px</span>
+              </div>
               <input
-                type="number"
+                type="range"
                 min={6}
                 max={48}
+                step={1}
                 value={startCap.size}
                 onChange={(event) => handleEndpointSizeChange('start', event)}
               />
@@ -273,12 +277,16 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
                 ))}
               </select>
             </label>
-            <label className="connector-toolbar__field">
-              <span>Size</span>
+            <label className="connector-toolbar__field connector-toolbar__field--block connector-toolbar__field--slider">
+              <div className="connector-toolbar__field-header">
+                <span>Size</span>
+                <span className="connector-toolbar__value">{endCap.size}px</span>
+              </div>
               <input
-                type="number"
+                type="range"
                 min={6}
                 max={48}
+                step={1}
                 value={endCap.size}
                 onChange={(event) => handleEndpointSizeChange('end', event)}
               />

--- a/src/styles/connector-toolbar.css
+++ b/src/styles/connector-toolbar.css
@@ -109,6 +109,28 @@
   flex: 1 1 100%;
 }
 
+.connector-toolbar__field--slider {
+  flex-direction: column;
+  align-items: stretch;
+  gap: calc(6px * var(--menu-scale));
+}
+
+.connector-toolbar__field-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  font-size: calc(11px * var(--menu-scale));
+  color: rgba(226, 232, 240, 0.72);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.connector-toolbar__value {
+  font-variant-numeric: tabular-nums;
+  color: rgba(226, 232, 240, 0.82);
+}
+
 .connector-toolbar__field--color {
   flex: 0 0 auto;
 }
@@ -150,6 +172,9 @@
   font-size: calc(12px * var(--menu-scale));
   cursor: pointer;
   transition: background 0.15s ease, border 0.15s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .connector-toolbar__button:hover {
@@ -165,5 +190,10 @@
 .connector-toolbar__button--toggle {
   flex: 0 0 auto;
   min-width: calc(92px * var(--menu-scale));
+}
+
+.connector-toolbar__button--block {
+  width: 100%;
+  justify-content: center;
 }
 


### PR DESCRIPTION
## Summary
- replace connector endpoint size number fields with sliders positioned beneath the shape selector
- tweak connector toolbar styling so the dashed toggle spans the panel and slider labels show the current size value

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68dad9a83608832d9daae554f6ce8cfd