### PR TITLE
Add none option for connector endpoint caps

### DIFF
--- a/src/components/ConnectorToolbar.tsx
+++ b/src/components/ConnectorToolbar.tsx
@@ -157,6 +157,7 @@ export const ConnectorToolbar: React.FC<ConnectorToolbarProps> = ({
   const endCap = endpointStyles.end;
 
   const shapeOptions: Array<{ value: ConnectorEndpointShape; label: string }> = [
+    { value: 'none', label: 'None' },
     { value: 'arrow', label: 'Arrow' },
     { value: 'hollow-arrow', label: 'Hollow Arrow' },
     { value: 'triangle', label: 'Triangle' },

--- a/src/components/DiagramConnector.tsx
+++ b/src/components/DiagramConnector.tsx
@@ -101,6 +101,10 @@ const createEndpointCapElement = ({
   const baseWidth = size * 0.9;
   const baseHalfWidth = baseWidth / 2;
 
+  if (cap.shape === 'none') {
+    return <React.Fragment key={key} />;
+  }
+
   if (cap.shape === 'circle') {
     return (
       <circle

--- a/src/types/scene.ts
+++ b/src/types/scene.ts
@@ -80,7 +80,13 @@ export interface ConnectorStyle {
   cornerRadius?: number;
 }
 
-export type ConnectorEndpointShape = 'circle' | 'diamond' | 'arrow' | 'triangle' | 'hollow-arrow';
+export type ConnectorEndpointShape =
+  | 'none'
+  | 'circle'
+  | 'diamond'
+  | 'arrow'
+  | 'triangle'
+  | 'hollow-arrow';
 
 export interface ConnectorEndpointCap {
   shape: ConnectorEndpointShape;


### PR DESCRIPTION
## Summary
- allow connector endpoint menus to choose a "None" cap option
- prevent rendering a cap when "None" is selected while keeping existing defaults untouched

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68db46d90f78832d900e331a9d7724da