### PR TITLE
Enable spell checking while editing or selecting items

### DIFF
--- a/src/components/DiagramConnector.tsx
+++ b/src/components/DiagramConnector.tsx
@@ -742,7 +742,7 @@ export const DiagramConnector: React.FC<DiagramConnectorProps> = ({
               data-placeholder="Label"
               contentEditable={labelEditing}
               suppressContentEditableWarning
-              spellCheck={false}
+              spellCheck={labelEditing || selected}
               translate="no"
               style={{
                 fontSize: labelFontSize,

--- a/src/components/InlineTextEditor.tsx
+++ b/src/components/InlineTextEditor.tsx
@@ -250,7 +250,7 @@ const InlineTextEditorComponent = (
         style={contentStyle}
         contentEditable
         suppressContentEditableWarning
-        spellCheck={false}
+        spellCheck={true}
         translate="no"
         role="textbox"
         aria-multiline="true"


### PR DESCRIPTION
## Summary
- enable spell checking in the inline text editor so node text highlights typos while being edited
- allow connector labels to surface spell check suggestions when the label is being edited or the connector is selected

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68dc3a6b6424832daca492f33755659c