### PR TITLE
Add offline desktop packaging script and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ dist
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+# Generated offline desktop bundles
+public/desktop/*.zip
+public/desktop/**/*.zip
+/desktop/

--- a/README.md
+++ b/README.md
@@ -20,6 +20,17 @@ npm config set registry https://registry.npmmirror.com
 - `npm run dev` – start the Vite development server.
 - `npm run build` – type-check and produce a production build.
 - `npm run preview` – preview the build output locally.
+- `npm run package:offline` – build and archive the offline desktop bundle without running the production build.
+
+## Offline Desktop Bundle
+
+The project now ships with an automated packaging step that prepares a downloadable desktop bundle whenever `npm run build` (or `npm run package:offline`) runs. The workflow is designed to work within GitHub pull requests without committing large binary artifacts:
+
+1. The packaging script runs `vite build --mode offline` with a relative base path so the generated `index.html` and assets work from the local filesystem.
+2. The resulting bundle is zipped into `desktop/schematics-studio.zip` and duplicated to `public/desktop/schematics-studio.zip`, which the web app serves through the “Download for desktop” button.
+3. Inside the archive you will find a `README.txt` explaining how to extract the files and open `index.html` in a modern browser. The in-app “Download” and “Upload” buttons continue to save and reopen the existing `.json` board format entirely offline.
+
+Because the archive is generated during the build, no binary files live in the repository—avoiding the “Binary files are not supported” errors seen in previous attempts. When publishing a new release, run `npm run build` and upload `desktop/schematics-studio.zip` from the project root as the downloadable desktop artifact.
 
 ## Current Capabilities
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "prebuild": "node scripts/package-offline.mjs",
     "dev": "vite",
     "build": "tsc && vite build",
+    "package:offline": "node scripts/package-offline.mjs",
     "test": "node -e \"fs.rmSync('build-tests',{recursive:true,force:true});\" && tsc --project tsconfig.tests.json && node scripts/fix-esm-extensions.mjs && node --test build-tests/utils/__tests__/*.js",
     "preview": "vite preview"
   },

--- a/public/desktop/README.md
+++ b/public/desktop/README.md
@@ -1,0 +1,3 @@
+# Offline desktop builds
+
+This directory will contain generated offline packages when 'npm run package:offline' is executed.

--- a/scripts/package-offline.mjs
+++ b/scripts/package-offline.mjs
@@ -1,0 +1,90 @@
+import { build as viteBuild } from 'vite';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { copyFile, mkdir, rm, writeFile } from 'node:fs/promises';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..');
+const desktopDir = path.join(rootDir, 'desktop');
+const offlineOutDir = path.join(desktopDir, 'schematics-studio');
+const archivePath = path.join(desktopDir, 'schematics-studio.zip');
+const publicDesktopDir = path.join(rootDir, 'public', 'desktop');
+const publicArchivePath = path.join(publicDesktopDir, 'schematics-studio.zip');
+const offlineReadmePath = path.join(offlineOutDir, 'README.txt');
+
+const OFFLINE_README = `Schematics Studio Offline\n===========================\n\nThanks for downloading the offline build!\n\nGetting started:\n1. Extract the contents of this archive to a folder on your computer.\n2. Open the file named \"index.html\" in a modern Chromium, Firefox, or Safari browser.\n3. The editor runs entirely in your browser tab. Use the \"Download\" and \"Upload\" buttons in the toolbar to save and reopen *.json boards.\n\nBecause everything is stored locally, the browser's undo history will be cleared if you refresh the tab.\n`; // eslint-disable-line max-len
+
+async function ensureCleanWorkspace() {
+  await mkdir(desktopDir, { recursive: true });
+  await rm(offlineOutDir, { recursive: true, force: true });
+  await rm(archivePath, { force: true });
+}
+
+async function runOfflineBuild() {
+  await viteBuild({
+    configFile: path.join(rootDir, 'vite.config.ts'),
+    root: rootDir,
+    mode: 'offline',
+    build: {
+      outDir: offlineOutDir,
+      emptyOutDir: true
+    }
+  });
+}
+
+async function writeOfflineReadme() {
+  await writeFile(offlineReadmePath, OFFLINE_README, 'utf8');
+}
+
+async function createArchive() {
+  await mkdir(desktopDir, { recursive: true });
+  await rm(archivePath, { force: true });
+
+  await new Promise((resolve, reject) => {
+    const child = spawn('zip', ['-r', '-q', archivePath, '.'], {
+      cwd: offlineOutDir,
+      stdio: 'inherit'
+    });
+
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`zip exited with code ${code}`));
+      }
+    });
+
+    child.on('error', (error) => {
+      if (error.code === 'ENOENT') {
+        reject(new Error('The "zip" command is required to package the offline build. Install a zip utility and try again.'));
+      } else {
+        reject(error);
+      }
+    });
+  });
+}
+
+async function copyArchiveToPublic() {
+  await mkdir(publicDesktopDir, { recursive: true });
+  await rm(publicArchivePath, { force: true });
+  await copyFile(archivePath, publicArchivePath);
+}
+
+async function main() {
+  console.info('[package-offline] Preparing offline desktop package...');
+  await ensureCleanWorkspace();
+  await runOfflineBuild();
+  await writeOfflineReadme();
+  await createArchive();
+  await copyArchiveToPublic();
+  console.info('[package-offline] Offline package ready at', archivePath);
+  console.info('[package-offline] Public copy available at', publicArchivePath);
+}
+
+main().catch((error) => {
+  console.error('[package-offline] Failed to create offline package');
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
+  base: mode === 'offline' ? './' : '/',
   plugins: [react()],
   server: {
     port: 5173,
     host: true
   }
-});
+}));


### PR DESCRIPTION
## Summary
- add a build script that prepares an offline desktop bundle, zips it, and exposes the archive through the web app
- make the Vite configuration mode-aware so offline builds use a relative base path and ignore generated artifacts
- document the offline bundle workflow and add a placeholder README for the generated public directory

## Testing
- `npm run package:offline`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68dd5496e988832db1c8c1e796029198