### PR TITLE
Fix node border scaling with zoom

### DIFF
--- a/src/components/DiagramNode.tsx
+++ b/src/components/DiagramNode.tsx
@@ -37,8 +37,7 @@ const renderShape = (
     fillOpacity,
     stroke,
     strokeWidth,
-    className,
-    vectorEffect: 'non-scaling-stroke' as const
+    className
   };
 
   switch (node.shape) {


### PR DESCRIPTION
## Summary
- allow node borders and outlines to scale with the canvas zoom by relying on scalable SVG strokes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68de9cf5af88832da24c2d86e4d5e538