### PR TITLE
Allow deeper canvas zoom out for large boards

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -88,7 +88,8 @@ import { ensureHttpProtocol } from '../utils/url';
 import { getImageDimensions, readFileAsDataUrl } from '../utils/image';
 import '../styles/canvas.css';
 
-const MIN_SCALE = 0.2;
+// Allow users to comfortably view very large boards by permitting deeper zoom-outs.
+const MIN_SCALE = 0.05;
 const MAX_SCALE = 4;
 const ZOOM_FACTOR = 1.1;
 const FIT_PADDING = 160;


### PR DESCRIPTION
## Summary
- lower the canvas minimum zoom level so large boards remain fully visible
- document the intent to support wide zoom ranges directly in the canvas constants

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68deb5327500832db5340a1c946292b7