### PR TITLE
Handle pasting images copied via browser context menu

### DIFF
--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -1,9 +1,9 @@
-export const readFileAsDataUrl = (file: File): Promise<string> =>
+const readBlobAsDataUrl = (blob: Blob): Promise<string> =>
   new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onerror = () => {
       reader.abort();
-      reject(new Error('Unable to read image file'));
+      reject(new Error('Unable to read image data'));
     };
     reader.onload = () => {
       const result = reader.result;
@@ -13,8 +13,20 @@ export const readFileAsDataUrl = (file: File): Promise<string> =>
         reject(new Error('Unexpected image data format'));
       }
     };
-    reader.readAsDataURL(file);
+    reader.readAsDataURL(blob);
   });
+
+export const readFileAsDataUrl = (file: File): Promise<string> => readBlobAsDataUrl(file);
+
+export const fetchImageAsDataUrl = async (url: string): Promise<string> => {
+  const response = await fetch(url, { mode: 'cors' });
+  if (!response.ok) {
+    throw new Error('Failed to fetch image');
+  }
+
+  const blob = await response.blob();
+  return readBlobAsDataUrl(blob);
+};
 
 export const getImageDimensions = (src: string): Promise<{ width: number; height: number }> =>
   new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- detect image sources in clipboard HTML and URLs so pasting works after using "Copy image"
- add utilities to convert fetched image responses into data URLs for canvas nodes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e1211d238c832da7f5383fd97a22e5