### PR TITLE
Fix text selection clearing when adjusting color

### DIFF
--- a/src/components/SelectionToolbar.tsx
+++ b/src/components/SelectionToolbar.tsx
@@ -592,22 +592,19 @@ const SelectionToolbarContent: React.FC<SelectionToolbarContentProps> = ({
     saveSelection();
 
     const input = event.currentTarget;
-    const cleanup = () => {
-      if (textColorInteractionCleanupRef.current) {
-        document.removeEventListener('pointerup', handlePointerUp, true);
-        document.removeEventListener('pointercancel', handlePointerUp, true);
-        input.removeEventListener('blur', handleBlur);
-        textColorInteractionRef.current = false;
-        textColorInteractionCleanupRef.current = null;
-      }
-    };
-
-    const handlePointerUp = () => {
-      cleanup();
-    };
 
     const handleBlur = () => {
       cleanup();
+    };
+
+    const cleanup = () => {
+      if (textColorInteractionCleanupRef.current !== cleanup) {
+        return;
+      }
+      input.removeEventListener('blur', handleBlur);
+      textColorInteractionRef.current = false;
+      textColorInteractionCleanupRef.current = null;
+      restoreSelection();
     };
 
     if (textColorInteractionCleanupRef.current) {
@@ -617,8 +614,6 @@ const SelectionToolbarContent: React.FC<SelectionToolbarContentProps> = ({
     textColorInteractionRef.current = true;
     textColorInteractionCleanupRef.current = cleanup;
 
-    document.addEventListener('pointerup', handlePointerUp, true);
-    document.addEventListener('pointercancel', handlePointerUp, true);
     input.addEventListener('blur', handleBlur);
 
     requestAnimationFrame(() => {

--- a/src/components/SelectionToolbar.tsx
+++ b/src/components/SelectionToolbar.tsx
@@ -317,8 +317,10 @@ const SelectionToolbarContent: React.FC<SelectionToolbarContentProps> = ({
     if (!selection) {
       return;
     }
+    const restoredRange = range.cloneRange();
     selection.removeAllRanges();
-    selection.addRange(range);
+    selection.addRange(restoredRange);
+    savedSelectionRef.current = restoredRange;
   }, [isTextEditing]);
 
   const handleFillChange = useCallback(


### PR DESCRIPTION
## Summary
- keep the inline text selection saved while the text color picker is open
- ignore selectionchange updates triggered by the color input and restore the saved range when necessary
- clean up temporary event listeners tied to color input interactions

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e1323bbe08832d97dfb9cb0206b81e