### PR TITLE
Hide connector handles while connection is in progress

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -3560,6 +3560,7 @@ const CanvasComponent = (
               selected={selectedNodeIds.includes(node.id)}
               hovered={hoveredNodeId === node.id}
               tool={tool as Tool}
+              showConnectorHandles={pendingConnection === null}
               editing={editingNodeId === node.id}
               onPointerDown={(event) => handleNodePointerDown(event, node)}
               onPointerUp={(event) => handleNodePointerUp(event, node)}

--- a/src/components/DiagramNode.tsx
+++ b/src/components/DiagramNode.tsx
@@ -7,6 +7,7 @@ interface DiagramNodeProps {
   selected: boolean;
   hovered: boolean;
   tool: Tool;
+  showConnectorHandles?: boolean;
   editing: boolean;
   onPointerDown: (event: React.PointerEvent<SVGGElement>) => void;
   onPointerUp: (event: React.PointerEvent<SVGGElement>) => void;
@@ -80,6 +81,7 @@ export const DiagramNode: React.FC<DiagramNodeProps> = ({
   selected,
   hovered,
   tool,
+  showConnectorHandles = true,
   editing,
   onPointerDown,
   onPointerUp,
@@ -105,7 +107,8 @@ export const DiagramNode: React.FC<DiagramNodeProps> = ({
     className: 'diagram-node__outline'
   });
 
-  const cursor = tool === 'connector' ? 'crosshair' : 'move';
+  const isConnectorTool = tool === 'connector';
+  const cursor = isConnectorTool ? 'crosshair' : 'move';
 
   const connectorHandleOffset = 20;
   const connectorAnchors = getConnectorPortPositions(node);
@@ -189,7 +192,7 @@ export const DiagramNode: React.FC<DiagramNodeProps> = ({
         <DiagramNodeImage node={node} />
       )}
       {outlineElement}
-      {tool === 'connector' && (
+      {isConnectorTool && showConnectorHandles && (
         <g className="diagram-node__connector-handles">
           {connectorHandles.map((handle) => (
             <circle


### PR DESCRIPTION
## Summary
- hide connector grab handles on nodes whenever a connector creation or reconnection is pending
- keep DiagramNode cursor logic intact while allowing handles to be re-enabled after the connection completes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e14455cca4832d8a4163f0e31a8604