### PR TITLE
Set favicon to match startup board image

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      rel="icon"
+      type="image/png"
+      href="https://i.postimg.cc/8CyDmHF7/int-icon-no-border.png"
+    />
     <title>Schematics Studio</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- add a favicon link to reuse the startup board image in the browser tab

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e16ed94564832daaae5ac2b8052b8e